### PR TITLE
changed branch from gpus to master

### DIFF
--- a/conf/patches/gpu-nodes.yaml
+++ b/conf/patches/gpu-nodes.yaml
@@ -9,7 +9,7 @@ spec:
     - docker-healthcheck.service
     manifest: |
       Type=oneshot
-      ExecStart=/bin/bash -c '/usr/bin/curl -L -S -f https://raw.githubusercontent.com/vanvalenlab/kiosk/gpus/scripts/nvidia-docker-installer.sh | /bin/bash -x'
+      ExecStart=/bin/bash -c '/usr/bin/curl -L -S -f https://raw.githubusercontent.com/vanvalenlab/kiosk/master/scripts/nvidia-docker-installer.sh | /bin/bash -x'
     name: nvidia-docker-install.service
   minSize: 0
   maxSize: 2


### PR DESCRIPTION
Pulling a resource from a non-`master` branch is a bad idea long-term and failed on us today. This patches that.