### PR TITLE
added DEBUG environmental variable

### DIFF
--- a/conf/charts/tf-serving/values.yaml
+++ b/conf/charts/tf-serving/values.yaml
@@ -26,6 +26,7 @@ env:
   CLOUD_PROVIDER: "aws"
   TF_SERVING_CONFIG_FILE: "/kiosk/tf-serving/models.conf"
   LOG_LEVEL: "3"
+  DEBUG: "FALSE"
 secrets:
   AWS_ACCESS_KEY_ID: "change_me"
   AWS_SECRET_ACCESS_KEY: "change_me"

--- a/conf/helmfile.d/0310.tf-serving.yaml
+++ b/conf/helmfile.d/0310.tf-serving.yaml
@@ -50,6 +50,7 @@ releases:
         TF_SERVING_CONFIG_FILE: "/kiosk/tf-serving/models.conf"
         CLOUD_PROVIDER: '{{ env "CLOUD_PROVIDER" | default "aws" }}'
         LOG_LEVEL: "3"
+        DEBUG: "FALSE"
       secrets:
         AWS_ACCESS_KEY_ID: '{{ env "AWS_ACCESS_KEY_ID" | default "NA" }}'
         AWS_SECRET_ACCESS_KEY: '{{ env "AWS_SECRET_ACCESS_KEY" | default "NA" }}'


### PR DESCRIPTION
This commit, in conjunction with the commit in the `gke_cleanup` branch of the `kiosk-tf-serving` project, gives the tf-serving container the option of either 1) executing its standard startup script or 2) entering a very long sleep loop, allowing the Kubernetes admin to `exec` into the container and start tf-serving manually, so that the person can see all of the debug info from tf-serving.

It might not be a bad idea to add this `DEBUG` functionality to all startup scripts used by kiosk containers.