### PR TITLE
Create geodesic folder

### DIFF
--- a/conf/tasks/Makefile.kops
+++ b/conf/tasks/Makefile.kops
@@ -3,6 +3,10 @@ SSH_PUBLIC_KEY ?= $(SSH_KEY).pub
 
 ## Create SSH key for Kops cluster
 kops/create/ssh-key:
+	@if [ ! -d "$(CACHE_PATH)" ] \
+	then \
+		mkdir $(CACHE_PATH) \
+	fi
 	@ssh-keygen -t rsa -f $(SSH_KEY) -N ""
 
 ## Destroy SSH key for Kops cluster

--- a/conf/tasks/Makefile.kops
+++ b/conf/tasks/Makefile.kops
@@ -3,10 +3,7 @@ SSH_PUBLIC_KEY ?= $(SSH_KEY).pub
 
 ## Create SSH key for Kops cluster
 kops/create/ssh-key:
-	@if [ ! -d "$(CACHE_PATH)" ] \
-	then \
-		mkdir $(CACHE_PATH) \
-	fi
+	@if [ ! -d "$(CACHE_PATH)" ] ; then mkdir $(CACHE_PATH); fi
 	@ssh-keygen -t rsa -f $(SSH_KEY) -N ""
 
 ## Destroy SSH key for Kops cluster

--- a/conf/tasks/Makefile.kops
+++ b/conf/tasks/Makefile.kops
@@ -3,7 +3,10 @@ SSH_PUBLIC_KEY ?= $(SSH_KEY).pub
 
 ## Create SSH key for Kops cluster
 kops/create/ssh-key:
-	@if [ ! -d "$(CACHE_PATH)" ] ; then mkdir $(CACHE_PATH); fi
+	@if [ ! -d "$(CACHE_PATH)" ]; \
+	then \
+	    mkdir $(CACHE_PATH); \
+	fi
 	@ssh-keygen -t rsa -f $(SSH_KEY) -N ""
 
 ## Destroy SSH key for Kops cluster


### PR DESCRIPTION
When running on AWS, the step where we create a keypair for use in communicating with the EC2 instances would sometime fail because the `~/.geodesic` folder didn't exist. We now create this folder as part of the AWS cluster creation process, if it doesn't already exist.

It's worth noting that this error never occurred in Google Cloud because we chose to use web-based authentication, instead of certificate-based authentication.