### PR TITLE
Display cluster ip

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,11 @@ The preparation steps vary depending on which cloud provider you plan on deployi
 
 ## Kiosk usage
 
-1. Once the Kiosk has started, select the configuration option for your chosen cloud provider, either Amazon or Google, and fill out the configuration values as needed. ( If using Google, follow the provided link in a browser.) Once the Kiosk has been configured for a cloud provider, the word `(active)` will appear next to that cloud provider's configuration option in the Kiosk menu.
+1. Once the Kiosk has started, select the configuration option for your chosen cloud provider, either Amazon or Google, and fill out the configuration values as needed. ( If using Google, follow the link provided during the configuration process in a web browser.) Once the Kiosk has been configured for a cloud provider, the word `(active)` will appear next to that cloud provider's configuration option in the Kiosk menu.
 2. With the Kiosk configured for the appropriate cloud provider, select the `Create` option from the Kiosk's main menu to create the cluster on the chosen cloud provider. This may take up to 10 minutes. Cluster creation is done when you see `Cluster Created` followed by `---COMPLETE---` printed to the terminal. If you see `---COMPLETE---` with some error text immediately preceding it, cluster creation failed.
-3. Go to the cluster frontpage in your browser. (Currently, the most efficient way to find the public IP address or URL of your cluster is to select `Shell` form the Kiosk's main menu and paste the following command into the terminal: `kubectl describe service --namespace=kube-system ingress-nginx-ingress-controller` and then find the IP address or URL listed in the `LoadBalancer Ingress` field of the output.)
+3. Find the cluster's web address by choosing the `View` option form the Kiosk's main menu. (Depending on your chosne cloud provider and the cloud provider's settings, your cluster's address might be either a raw IP address, e.g., "123.456.789.012", or a URL, e.g., "deepcellkiosk.cloudprovider.com".
+4. Go to the cluster address in your web browser to find the Deepcell frontpage.
+5. Enjoy!
 
 ## Kiosk shutdown
 

--- a/conf/Makefile
+++ b/conf/Makefile
@@ -7,7 +7,8 @@ include tasks/Makefile.*
 ## Create cluster
 create: \
   $(CLOUD_PROVIDER)/create/all \
-  helmfile/create/all
+  helmfile/create/all \
+  kubectl/display/ip
 	@echo "Cluster created"
 
 ## Destroy cluster

--- a/conf/tasks/Makefile.kubectl
+++ b/conf/tasks/Makefile.kubectl
@@ -19,11 +19,11 @@ kubectl/create/all: \
 
 
 ## Display the cluster IP or URL
-kubectl/display/ip: IP_VAR = $(shell sh -c "kubectl describe service --namespace=kube-system ingress-nginx-ingress-controller | grep 'LoadBalancer Ingress:' | sed 's/\([[:graph:]]\+[[:space:]]\+\)\+\([0-9.]\+\)/\2/'")
+kubectl/display/ip: IP_VAR = $(shell sh -c "kubectl describe service --namespace=kube-system ingress-nginx-ingress-controller | grep 'LoadBalancer Ingress:' | sed 's/\([[:graph:]]\+[[:space:]]\+\)\+\([0-9.]\+\|[[:graph:]]\+amazon[[:graph:]]\+\)/\2/'")
 kubectl/display/ip:
 	@echo " "
 	@echo " "
 	@echo Cluster address: ${IP_VAR}
 	@echo " "
 	@echo " "
-	@echo export CLUSTER_IP_TESTT=${IP_VAR} > ./cluster_address
+	@echo export CLUSTER_IP_TEST=${IP_VAR} > ./cluster_address

--- a/conf/tasks/Makefile.kubectl
+++ b/conf/tasks/Makefile.kubectl
@@ -17,4 +17,6 @@ kubectl/create/all: \
   kubectl/create/nvidia-drivers
 	@echo "Kubectl provisioned"
 
-
+## Display the cluster IP or URL
+kubectl/display/ip: \
+	kubectl describe service --namespace=kube-system ingress-nginx-ingress-controller | grep "Load"

--- a/conf/tasks/Makefile.kubectl
+++ b/conf/tasks/Makefile.kubectl
@@ -26,4 +26,4 @@ kubectl/display/ip:
 	@echo Cluster address: ${IP_VAR}
 	@echo " "
 	@echo " "
-	@echo export CLUSTER_IP_TEST=${IP_VAR} > ./cluster_address
+	@echo export CLUSTER_ADDRESS=${IP_VAR} > ./cluster_address

--- a/conf/tasks/Makefile.kubectl
+++ b/conf/tasks/Makefile.kubectl
@@ -17,6 +17,13 @@ kubectl/create/all: \
   kubectl/create/nvidia-drivers
 	@echo "Kubectl provisioned"
 
+
 ## Display the cluster IP or URL
-kubectl/display/ip: \
-	kubectl describe service --namespace=kube-system ingress-nginx-ingress-controller | grep "Load"
+kubectl/display/ip: IP_VAR = $(shell sh -c "kubectl describe service --namespace=kube-system ingress-nginx-ingress-controller | grep 'LoadBalancer Ingress:' | sed 's/\([[:graph:]]\+[[:space:]]\+\)\+\([0-9.]\+\)/\2/'")
+kubectl/display/ip:
+	@echo " "
+	@echo " "
+	@echo Cluster address: ${IP_VAR}
+	@echo " "
+	@echo " "
+	@echo export CLUSTER_IP_TESTT=${IP_VAR} > ./cluster_address

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -73,20 +73,21 @@ function tailcmd() {
 
 function menu() {
   local value
+  source ./cluster_address
+  cluster_address=${CLUSTER_IP_TESTT:-(none)}
   local header_text=("You can use the UP/DOWN arrow keys, the first\n"
                      "letter of the choice as a hot key, or the\n"
                      "number keys 1-9 to choose an option.\n"
                      "Choose a task.\n\n"
-		     "Cluster address: ${cluster_address}"
+		     "    Cluster address:   ${cluster_address}"
 		     " \n"
 		     " \n")
 
   declare -A cloud_providers
   cloud_providers[${CLOUD_PROVIDER:-none}]="(active)"
-  cluster_address="(none)"
   value=$(dialog --clear  --help-button --backtitle "${BRAND}" \
             --title "[ M A I N - M E N U ]" \
-            --menu "${header_text[*]}" 18 50 6 \
+            --menu "${header_text[*]}" 19 50 6 \
                 "AWS"     "Configure Amazon ${cloud_providers[aws]}" \
                 "GKE"     "Configure Google ${cloud_providers[gke]}" \
                 "Create"  "Create ${CLOUD_PROVIDER^^} Cluster" \

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -73,25 +73,21 @@ function tailcmd() {
 
 function menu() {
   local value
-  source ./cluster_address
-  cluster_address=${CLUSTER_IP_TESTT:-(none)}
   local header_text=("You can use the UP/DOWN arrow keys, the first\n"
                      "letter of the choice as a hot key, or the\n"
                      "number keys 1-9 to choose an option.\n"
-                     "Choose a task.\n\n"
-		     "    Cluster address:   ${cluster_address}"
-		     " \n"
-		     " \n")
+                     "Choose a task.")
 
   declare -A cloud_providers
   cloud_providers[${CLOUD_PROVIDER:-none}]="(active)"
   value=$(dialog --clear  --help-button --backtitle "${BRAND}" \
             --title "[ M A I N - M E N U ]" \
-            --menu "${header_text[*]}" 19 50 6 \
+            --menu "${header_text[*]}" 17 50 7 \
                 "AWS"     "Configure Amazon ${cloud_providers[aws]}" \
                 "GKE"     "Configure Google ${cloud_providers[gke]}" \
-                "Create"  "Create ${CLOUD_PROVIDER^^} Cluster" \
+		"Create"  "Create ${CLOUD_PROVIDER^^} Cluster" \
                 "Destroy" "Destroy ${CLOUD_PROVIDER^^} Cluster" \
+		"View"    "View Cluster Address" \
                 "Shell"   "Drop to the shell" \
                 "Exit"    "Exit this kiosk" \
             --output-fd 1 \
@@ -147,6 +143,18 @@ function destroy() {
   tailcmd "Destroy Cluster" "---COMPLETE--" make destroy
 }
 
+function view() {
+  local title="Deepcell Cluster Address"
+  source ./cluster_address
+  local cluster_address=${CLUSTER_IP_TEST:-(no current address)}
+  dialog --clear \
+         --begin 0 0 \
+         --title "$title" \
+         --backtitle "${BRAND}" \
+         --begin 3 1 \
+         --msgbox "${cluster_address}" $((LINES-5)) $((COLUMNS-3))
+}
+
 function main() {
   export MENU=true
   msgbox "Welcome!" "Welcome to the Deepcell Kiosk"
@@ -163,6 +171,7 @@ function main() {
       "GKE") configure_gke ;;
       "Create") create ;;
       "Destroy") destroy;;
+      "View") view;;
       "Exit") break ;;
     esac
   done

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -145,14 +145,22 @@ function destroy() {
 
 function view() {
   local title="Deepcell Cluster Address"
-  source ./cluster_address
-  local cluster_address=${CLUSTER_IP_TEST:-(no current address)}
-  dialog --clear \
-         --begin 0 0 \
-         --title "$title" \
-         --backtitle "${BRAND}" \
-         --begin 3 1 \
-         --msgbox "${cluster_address}" $((LINES-5)) $((COLUMNS-3))
+  if [ -f ./cluster_address ]; then
+	  local cluster_address=$(cat ./cluster_address | sed 's/export CLUSTER_ADDRESS=\([[:graph:]]\+\)/\1/')
+  else
+	  local cluster_address="No current address -- no cluster has been started yet."
+  fi
+  clear
+  echo "The cluster's address is: " ${cluster_address}
+  read -p "Press enter to return to main menu"
+  #source ./cluster_address
+  #local cluster_address=${CLUSTER_IP_TEST:-(no current address)}
+  #dialog --clear \
+  #       --begin 0 0 \
+  #       --title "$title" \
+  #       --backtitle "${BRAND}" \
+  #       --begin 3 1 \
+  #       --msgbox "${cluster_address}" $((LINES-5)) $((COLUMNS-3))
 }
 
 function main() {

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -73,17 +73,20 @@ function tailcmd() {
 
 function menu() {
   local value
-  local help=("You can use the UP/DOWN arrow keys, the first\n"
-              "letter of the choice as a hot key, or the\n"
-              "number keys 1-9 to choose an option.\n"
-              "Choose a task.")
+  local header_text=("You can use the UP/DOWN arrow keys, the first\n"
+                     "letter of the choice as a hot key, or the\n"
+                     "number keys 1-9 to choose an option.\n"
+                     "Choose a task.\n\n"
+		     "Cluster address: ${cluster_address}"
+		     " \n"
+		     " \n")
 
   declare -A cloud_providers
   cloud_providers[${CLOUD_PROVIDER:-none}]="(active)"
-
+  cluster_address="(none)"
   value=$(dialog --clear  --help-button --backtitle "${BRAND}" \
             --title "[ M A I N - M E N U ]" \
-            --menu "${help[*]}" 16 50 6 \
+            --menu "${header_text[*]}" 18 50 6 \
                 "AWS"     "Configure Amazon ${cloud_providers[aws]}" \
                 "GKE"     "Configure Google ${cloud_providers[gke]}" \
                 "Create"  "Create ${CLOUD_PROVIDER^^} Cluster" \

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -153,14 +153,6 @@ function view() {
   clear
   echo "The cluster's address is: " ${cluster_address}
   read -p "Press enter to return to main menu"
-  #source ./cluster_address
-  #local cluster_address=${CLUSTER_IP_TEST:-(no current address)}
-  #dialog --clear \
-  #       --begin 0 0 \
-  #       --title "$title" \
-  #       --backtitle "${BRAND}" \
-  #       --begin 3 1 \
-  #       --msgbox "${cluster_address}" $((LINES-5)) $((COLUMNS-3))
 }
 
 function main() {


### PR DESCRIPTION
This improvement shows the cluster IP/URL on the front page of the kiosk menu once cluster has been started. Until then, it shows "(none)" as the cluster address.

This branch addresses issues #18 and #20.