### PR TITLE
Credential storage bugifx

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ push:
 
 ## Install wrapper script from geodesic container
 install:
-	@docker run --rm $(DOCKER_IMAGE_NAME) | sudo -E bash -s $(DOCKER_TAG)
+	@docker run --rm $(DOCKER_IMAGE_NAME) | bash -s $(DOCKER_TAG)
 
 ## Start the geodesic shell by calling wrapper script
 run:

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ push:
 
 ## Install wrapper script from geodesic container
 install:
-	@docker run --rm $(DOCKER_IMAGE_NAME) | bash -s $(DOCKER_TAG)
+	@docker run --rm $(DOCKER_IMAGE_NAME) | sudo -E bash -s $(DOCKER_TAG)
 
 ## Start the geodesic shell by calling wrapper script
 run:

--- a/conf/Makefile
+++ b/conf/Makefile
@@ -14,3 +14,10 @@ create: \
 destroy: \
   $(CLOUD_PROVIDER)/destroy/all
 	@echo "Cluster destroyed"
+
+## Create $CACHE_PATH directory, if it doesn't already exist
+create_cache_path:
+	@if [ ! -d "$(CACHE_PATH)" ]; \
+	then \
+	    mkdir $(CACHE_PATH); \
+	fi

--- a/conf/tasks/Makefile.kops
+++ b/conf/tasks/Makefile.kops
@@ -6,8 +6,8 @@ kops/create/ssh-key:
 	@if [ ! -d "$(CACHE_PATH)" ]; \
 	then \
 	    echo "It looks like you haven't run a cloud provider configuration yet."; \
-	    echo "At the very least the CACHE_PATH directory, " $(CACHE_PATH) ", does not exist.";\
-	    exit 1;
+	    echo "At the very least the CACHE_PATH directory, " $(CACHE_PATH) ", does not exist."; \
+	    exit 1; \
 	fi
 	@ssh-keygen -t rsa -f $(SSH_KEY) -N ""
 

--- a/conf/tasks/Makefile.kops
+++ b/conf/tasks/Makefile.kops
@@ -5,7 +5,9 @@ SSH_PUBLIC_KEY ?= $(SSH_KEY).pub
 kops/create/ssh-key:
 	@if [ ! -d "$(CACHE_PATH)" ]; \
 	then \
-	    mkdir $(CACHE_PATH); \
+	    echo "It looks like you haven't run a cloud provider configuration yet."; \
+	    echo "At the very least the CACHE_PATH directory, " $(CACHE_PATH) ", does not exist.";\
+	    exit 1;
 	fi
 	@ssh-keygen -t rsa -f $(SSH_KEY) -N ""
 

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -115,7 +115,8 @@ function configure_aws() {
   
   make create_cache_path
   printenv | grep -e CLOUD_PROVIDER > ${CACHE_PATH}/env
-  printenv | grep -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_S3_BUCKET -e NAMESPACE -e KOPS_CLUSTER_NAME -e KOPS_DNS_ZONE -e KOPS_STATE_STORE > ${CACHE_PATH}/env.aws
+  printenv | grep -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_S3_BUCKET -e NAMESPACE > ${CACHE_PATH}/env.aws
+  #printenv | grep -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_S3_BUCKET -e NAMESPACE -e KOPS_CLUSTER_NAME -e KOPS_DNS_ZONE -e KOPS_STATE_STORE > ${CACHE_PATH}/env.aws
 }
 
 function configure_gke() {

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -115,7 +115,7 @@ function configure_aws() {
   
   make create_cache_path
   printenv | grep -e CLOUD_PROVIDER > ${CACHE_PATH}/env
-  printenv | grep -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e NAMESPACE -e KOPS_CLUSTER_NAME -e KOPS_DNS_ZONE -e KOPS_STATE_STORE > ${CACHE_PATH}/env.aws
+  printenv | grep -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_S3_BUCKET -e NAMESPACE -e KOPS_CLUSTER_NAME -e KOPS_DNS_ZONE -e KOPS_STATE_STORE > ${CACHE_PATH}/env.aws
 }
 
 function configure_gke() {

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -113,6 +113,7 @@ function configure_aws() {
   export KOPS_STATE_STORE=s3://${NAMESPACE}
   export CLOUD_PROVIDER=aws
   
+  make create_cache_path
   printenv | grep -e CLOUD_PROVIDER > ${CACHE_PATH}/env
   printenv | grep -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e NAMESPACE -e KOPS_CLUSTER_NAME -e KOPS_DNS_ZONE -e KOPS_STATE_STORE > ${CACHE_PATH}/env.aws
 }
@@ -124,6 +125,7 @@ function configure_gke() {
   export CLOUD_PROVIDER=gke
   make gke/login
   
+  make create_cache_path
   printenv | grep -e CLOUD_PROVIDER > ${CACHE_PATH}/env
   printenv | grep -e PROJECT -e CLUSTER_NAME -e GKE_BUCKET > ${CACHE_PATH}/env.gke
 }


### PR DESCRIPTION
This branch fixes #24.

The reason credentials weren't getting saved sometimes was that the folder in which the configuration files were supposed to be stored was not being created until cluster creation, which necessarily occurs after the configuration process. Now, the folder is created during the configuration process, guaranteeing that it's always there once it's time to write the configuration file to disk.