### PR TITLE
Graceful command failure

### DIFF
--- a/conf/tasks/Makefile.aws
+++ b/conf/tasks/Makefile.aws
@@ -3,8 +3,9 @@
 ## Create AWS S3 bucket
 aws/create/bucket:
 	@echo "Creating AWS S3 bucket ${KOPS_STATE_STORE} in region ${KOPS_STATE_STORE_REGION} to act as storage for kops state files..."
-	@aws s3 mb "${KOPS_STATE_STORE}" --region "${KOPS_STATE_STORE_REGION}" 2> /dev/null || \
+	@aws s3 mb "${KOPS_STATE_STORE}" --region "${KOPS_STATE_STORE_REGION}" || \
 		echo "No bucket created. Bucket ${KOPS_STATE_STORE} in region ${KOPS_STATE_STORE_REGION} already exists."
+	@echo " "
 	@echo " "
 
 
@@ -20,7 +21,9 @@ aws/create/all: \
 ## Destroy AWS S3 bucket
 aws/destroy/bucket:
 	@echo "Deleting kops state store AWS S3 bucket ${KOPS_STATE_STORE} in region ${KOPS_STATE_STORE_REGION}."
-	@aws s3 rb "${KOPS_STATE_STORE}" --force 2> /dev/null || echo "Apparently, the bucket ${KOPS_STATE_STORE} didn't even exist."
+	@aws s3 rb "${KOPS_STATE_STORE}" --force || \
+		echo "Apparently, the bucket ${KOPS_STATE_STORE} didn't even exist."
+	@echo " "
 	@echo " "
 
 ## Destroy everything on AWS

--- a/conf/tasks/Makefile.aws
+++ b/conf/tasks/Makefile.aws
@@ -2,7 +2,11 @@
 
 ## Create AWS S3 bucket
 aws/create/bucket:
-	aws s3 mb "${KOPS_STATE_STORE}" --region "${KOPS_STATE_STORE_REGION}"
+	@echo "Creating AWS S3 bucket..."
+	@aws s3 mb "${KOPS_STATE_STORE}" --region "${KOPS_STATE_STORE_REGION}" 2> /dev/null || \
+		echo "No bucket created. Bucket ${KOPS_STATE_STORE} in region ${KOPS_STATE_STORE_REGION} already exists."
+	@echo " "
+
 
 ## Create everything on AWS
 aws/create/all: \

--- a/conf/tasks/Makefile.aws
+++ b/conf/tasks/Makefile.aws
@@ -2,7 +2,7 @@
 
 ## Create AWS S3 bucket
 aws/create/bucket:
-	@echo "Creating AWS S3 bucket..."
+	@echo "Creating AWS S3 bucket ${KOPS_STATE_STORE} in region ${KOPS_STATE_STORE_REGION} to act as storage for kops state files..."
 	@aws s3 mb "${KOPS_STATE_STORE}" --region "${KOPS_STATE_STORE_REGION}" 2> /dev/null || \
 		echo "No bucket created. Bucket ${KOPS_STATE_STORE} in region ${KOPS_STATE_STORE_REGION} already exists."
 	@echo " "
@@ -19,7 +19,9 @@ aws/create/all: \
 
 ## Destroy AWS S3 bucket
 aws/destroy/bucket:
-	aws s3 rb "${KOPS_STATE_STORE}" --force
+	@echo "Deleting kops state store AWS S3 bucket ${KOPS_STATE_STORE} in region ${KOPS_STATE_STORE_REGION}."
+	@aws s3 rb "${KOPS_STATE_STORE}" --force 2> /dev/null || echo "Apparently, the bucket ${KOPS_STATE_STORE} didn't even exist."
+	@echo " "
 
 ## Destroy everything on AWS
 aws/destroy/all: \

--- a/conf/tasks/Makefile.gke
+++ b/conf/tasks/Makefile.gke
@@ -75,7 +75,11 @@ gke/create/cluster:
 
 ## Destroy GKE cluster
 gke/destroy/cluster:
-	@gcloud container clusters --zone $(GKE_COMPUTE_ZONE) delete $(CLUSTER_NAME) --quiet
+	@echo "Destroying cluster..."
+	@-gcloud container clusters --zone $(GKE_COMPUTE_ZONE) delete $(CLUSTER_NAME) --quiet
+	@echo "Cluster destruction finished."
+	@echo " "
+	@echo " "
 
 ## Set context to use GKE cluster (e.g. with kubectl)
 gke/use/cluster:
@@ -141,7 +145,11 @@ gke/create/gpus:
 
 ## Destroy GKE GPU node pool
 gke/destroy/gpus:
-	-gcloud container node-pools delete gpu --quiet --zone $(GPU_COMPUTE_ZONE)
+	@echo "Destroying GPU node pool..."
+	@-gcloud container node-pools delete gpu --quiet --zone $(GPU_COMPUTE_ZONE)
+	@echo "GPU node pool destruction finished."
+	@echo " "
+	@echo " "
 
 # https://cloud.google.com/storage/docs/access-control/iam-roles
 ## Create Service Account used by deepcell
@@ -155,7 +163,11 @@ gke/create/service-account:
 
 ## Delete Service Account used by deepcell
 gke/destroy/service-account:
-	gcloud iam service-accounts delete $(GKE_NODE_SERVICE_ACCOUNT_EMAIL) --quiet
+	@echo "Destroying GKE service-account..."
+	@-gcloud iam service-accounts delete $(GKE_NODE_SERVICE_ACCOUNT_EMAIL) --quiet
+	@echo "GKE service-account destruction finished."
+	@echo " "
+	@echo " "
 
 ## Create bucket used by deepcell
 gke/create/bucket:

--- a/conf/tasks/Makefile.gke
+++ b/conf/tasks/Makefile.gke
@@ -48,7 +48,7 @@ gke/destroy/project:
 
 ## Create a new GKE cluster
 gke/create/cluster:
-	@echo "Creating GKE cluster."
+	@echo "Creating GKE cluster..."
 	@echo "Using the following command: "
 	@echo "    gcloud container clusters create $(CLUSTER_NAME) \ "
 	@echo "  	--service-account=$(GKE_NODE_SERVICE_ACCOUNT_EMAIL) \ "
@@ -103,7 +103,7 @@ gke/list/billing-accounts:
 # https://cloud.google.com/kubernetes-engine/docs/how-to/gpus
 ## Create GKE GPU node pool
 gke/create/gpus:
-	@echo "Creating GPU node pool."
+	@echo "Creating GPU node pool..."
 	@echo "Using the following command: "
 	@echo "    gcloud container node-pools create gpu \ "
 	@echo " 	--accelerator type=$(GPU_TYPE),count=$(GPU_PER_NODE) \ "
@@ -159,7 +159,7 @@ gke/destroy/service-account:
 
 ## Create bucket used by deepcell
 gke/create/bucket:
-	@echo "Creating Google Cloud Storage Bucket ${CLOUDSDK_CORE_PROJECT}."
+	@echo "Creating Google Cloud Storage Bucket ${CLOUDSDK_CORE_PROJECT}..."
 	@gsutil mb -p $(CLOUDSDK_CORE_PROJECT) gs://$(CLOUDSDK_BUCKET) 2> /dev/null \
 		|| echo "Bucket ${CLOUDSDK_CODE_PROJECT} already exists. No need to create that bucket."
 	@gsutil acl ch -u $(GKE_NODE_SERVICE_ACCOUNT_EMAIL):O gs://$(CLOUDSDK_BUCKET) 2> /dev/null
@@ -172,10 +172,12 @@ gke/destroy/bucket:
 
 ## Deploy helm tiller with service account
 gke/deploy/helm:
-	kubectl create serviceaccount --namespace kube-system tiller
-	kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:tiller
-	helm init --service-account tiller --upgrade --wait
-
+	@echo "Deploying kubernetes resources..."
+	@kubectl create serviceaccount --namespace kube-system tiller 2> /dev/null || echo "Kubernetes already appears to be deployed."
+	@kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:tiller 2> /dev/null || :
+	@helm init --service-account tiller --upgrade --wait &> /dev/null || :
+	@echo "Kubernetes resource deployment finished."
+	@echo " "
 
 gke/destroy/helm:
 	-helm reset --force --tiller-connection-timeout=2
@@ -184,7 +186,11 @@ gke/destroy/helm:
 	
 ## Deploy GKE Nvidia drivers
 gke/deploy/nvidia:
-	@kubectl apply -f https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/stable/nvidia-driver-installer/cos/daemonset-preloaded.yaml
+	@echo "Deploying NVIDIA drivers for GPU instances..."
+	@kubectl apply -f https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/stable/nvidia-driver-installer/cos/daemonset-preloaded.yaml || \
+		echo "These drivers are not being installed. They may already be installed."
+	@echo "NVIDIA GPU driver deployment finished."
+	@echo " "
 
 ## Create Cluster
 gke/create/all: \

--- a/conf/tasks/Makefile.gke
+++ b/conf/tasks/Makefile.gke
@@ -48,6 +48,17 @@ gke/destroy/project:
 
 ## Create a new GKE cluster
 gke/create/cluster:
+	@echo "Creating GKE cluster."
+	@echo "Using the following command: "
+	@echo "    gcloud container clusters create $(CLUSTER_NAME) \ "
+	@echo "  	--service-account=$(GKE_NODE_SERVICE_ACCOUNT_EMAIL) \ "
+	@echo " 	--zone=$(GKE_COMPUTE_ZONE) \ "
+	@echo " 	--max-nodes=$(NODE_MAX_SIZE) \ "
+	@echo " 	--min-nodes=$(NODE_MIN_SIZE) \ "
+	@echo " 	--machine-type=$(GKE_MACHINE_TYPE) \ "
+	@echo " 	--cluster-version $(KUBERNETES_VERSION) \ "
+	@echo " 	--enable-autoscaling \ "
+	@echo " 	--enable-autoupgrade 2> /dev/null"
 	@gcloud container clusters create $(CLUSTER_NAME) \
 		--service-account=$(GKE_NODE_SERVICE_ACCOUNT_EMAIL) \
 		--zone=$(GKE_COMPUTE_ZONE) \
@@ -56,7 +67,11 @@ gke/create/cluster:
 		--machine-type=$(GKE_MACHINE_TYPE) \
 		--cluster-version $(KUBERNETES_VERSION) \
 		--enable-autoscaling \
-		--enable-autoupgrade
+		--enable-autoupgrade \
+		2> /dev/null \
+		|| echo "Apparently, the cluster already exists."
+	@echo "GKE cluster creation complete."
+	@echo " "
 
 ## Destroy GKE cluster
 gke/destroy/cluster:
@@ -88,7 +103,22 @@ gke/list/billing-accounts:
 # https://cloud.google.com/kubernetes-engine/docs/how-to/gpus
 ## Create GKE GPU node pool
 gke/create/gpus:
-	gcloud container node-pools create gpu \
+	@echo "Creating GPU node pool."
+	@echo "Using the following command: "
+	@echo "    gcloud container node-pools create gpu \ "
+	@echo " 	--accelerator type=$(GPU_TYPE),count=$(GPU_PER_NODE) \ "
+	@echo " 	--service-account=$(GKE_NODE_SERVICE_ACCOUNT_EMAIL) \ "
+	@echo " 	--zone $(GPU_COMPUTE_ZONE) \ "
+	@echo " 	--cluster $(CLUSTER_NAME) \ "
+	@echo " 	--num-nodes $(GPU_NODE_MIN_SIZE) \ "
+	@echo " 	--min-nodes $(GPU_NODE_MIN_SIZE) \ "
+	@echo " 	--max-nodes $(GPU_NODE_MAX_SIZE) \ "
+	@echo " 	--machine-type=$(GPU_MACHINE_TYPE) \ "
+	@echo " 	--enable-autoscaling \ "
+	@echo " 	--enable-autorepair \ "
+	@echo " 	--enable-autoupgrade \ "
+	@echo "         2> /dev/null "
+	@gcloud container node-pools create gpu \
 		--accelerator type=$(GPU_TYPE),count=$(GPU_PER_NODE) \
 		--service-account=$(GKE_NODE_SERVICE_ACCOUNT_EMAIL) \
 		--zone $(GPU_COMPUTE_ZONE) \
@@ -99,7 +129,11 @@ gke/create/gpus:
 		--machine-type=$(GPU_MACHINE_TYPE) \
 		--enable-autoscaling \
 		--enable-autorepair \
-		--enable-autoupgrade
+		--enable-autoupgrade \
+		2> /dev/null \
+		|| echo "GPU node pool already exists."
+	@echo "GPU node pool completion finished."
+	@echo " "
 
 # https://cloud.google.com/kubernetes-engine/docs/how-to/gpus#gpu_pool
 # When you add a GPU node pool to an existing cluster that already runs a non-GPU node pool, GKE automatically taints the GPU nodes with the following node taint
@@ -112,8 +146,12 @@ gke/destroy/gpus:
 # https://cloud.google.com/storage/docs/access-control/iam-roles
 ## Create Service Account used by deepcell
 gke/create/service-account:
-	gcloud iam service-accounts create $(CLUSTER_NAME) --display-name "Deepcell" || echo "No need to create bucket."
-	gcloud projects add-iam-policy-binding $(CLOUDSDK_CORE_PROJECT) --member serviceAccount:$(GKE_NODE_SERVICE_ACCOUNT_EMAIL) --role roles/storage.admin
+	@echo "Creating GKE service account..."
+	@gcloud iam service-accounts create $(CLUSTER_NAME) --display-name "Deepcell" 2> /dev/null || \
+		echo "No need to create service account; it probably already exists."
+	@gcloud projects add-iam-policy-binding $(CLOUDSDK_CORE_PROJECT) --member serviceAccount:$(GKE_NODE_SERVICE_ACCOUNT_EMAIL) --role roles/storage.admin > /dev/null
+	@echo "GKE service account creation complete."
+	@echo " "
 
 ## Delete Service Account used by deepcell
 gke/destroy/service-account:
@@ -121,8 +159,12 @@ gke/destroy/service-account:
 
 ## Create bucket used by deepcell
 gke/create/bucket:
-	gsutil mb -p $(CLOUDSDK_CORE_PROJECT) gs://$(CLOUDSDK_BUCKET) || echo "No need to create bucket."
-	gsutil acl ch -u $(GKE_NODE_SERVICE_ACCOUNT_EMAIL):O gs://$(CLOUDSDK_BUCKET)
+	@echo "Creating Google Cloud Storage Bucket ${CLOUDSDK_CORE_PROJECT}."
+	@gsutil mb -p $(CLOUDSDK_CORE_PROJECT) gs://$(CLOUDSDK_BUCKET) 2> /dev/null \
+		|| echo "Bucket ${CLOUDSDK_CODE_PROJECT} already exists. No need to create that bucket."
+	@gsutil acl ch -u $(GKE_NODE_SERVICE_ACCOUNT_EMAIL):O gs://$(CLOUDSDK_BUCKET) 2> /dev/null
+	@echo "Google Cloud Storage Bucket creation finished."
+	@echo " "
 
 ## Destroy bucket used by deepcell
 gke/destroy/bucket:

--- a/conf/tasks/Makefile.gke
+++ b/conf/tasks/Makefile.gke
@@ -50,16 +50,7 @@ gke/destroy/project:
 gke/create/cluster:
 	@echo "Creating GKE cluster..."
 	@echo "Using the following command: "
-	@echo "    gcloud container clusters create $(CLUSTER_NAME) \ "
-	@echo "  	--service-account=$(GKE_NODE_SERVICE_ACCOUNT_EMAIL) \ "
-	@echo " 	--zone=$(GKE_COMPUTE_ZONE) \ "
-	@echo " 	--max-nodes=$(NODE_MAX_SIZE) \ "
-	@echo " 	--min-nodes=$(NODE_MIN_SIZE) \ "
-	@echo " 	--machine-type=$(GKE_MACHINE_TYPE) \ "
-	@echo " 	--cluster-version $(KUBERNETES_VERSION) \ "
-	@echo " 	--enable-autoscaling \ "
-	@echo " 	--enable-autoupgrade 2> /dev/null"
-	@gcloud container clusters create $(CLUSTER_NAME) \
+	gcloud container clusters create $(CLUSTER_NAME) \
 		--service-account=$(GKE_NODE_SERVICE_ACCOUNT_EMAIL) \
 		--zone=$(GKE_COMPUTE_ZONE) \
 		--max-nodes=$(NODE_MAX_SIZE) \
@@ -68,9 +59,9 @@ gke/create/cluster:
 		--cluster-version $(KUBERNETES_VERSION) \
 		--enable-autoscaling \
 		--enable-autoupgrade \
-		2> /dev/null \
 		|| echo "Apparently, the cluster already exists."
 	@echo "GKE cluster creation complete."
+	@echo " "
 	@echo " "
 
 ## Destroy GKE cluster
@@ -109,20 +100,7 @@ gke/list/billing-accounts:
 gke/create/gpus:
 	@echo "Creating GPU node pool..."
 	@echo "Using the following command: "
-	@echo "    gcloud container node-pools create gpu \ "
-	@echo " 	--accelerator type=$(GPU_TYPE),count=$(GPU_PER_NODE) \ "
-	@echo " 	--service-account=$(GKE_NODE_SERVICE_ACCOUNT_EMAIL) \ "
-	@echo " 	--zone $(GPU_COMPUTE_ZONE) \ "
-	@echo " 	--cluster $(CLUSTER_NAME) \ "
-	@echo " 	--num-nodes $(GPU_NODE_MIN_SIZE) \ "
-	@echo " 	--min-nodes $(GPU_NODE_MIN_SIZE) \ "
-	@echo " 	--max-nodes $(GPU_NODE_MAX_SIZE) \ "
-	@echo " 	--machine-type=$(GPU_MACHINE_TYPE) \ "
-	@echo " 	--enable-autoscaling \ "
-	@echo " 	--enable-autorepair \ "
-	@echo " 	--enable-autoupgrade \ "
-	@echo "         2> /dev/null "
-	@gcloud container node-pools create gpu \
+	gcloud container node-pools create gpu \
 		--accelerator type=$(GPU_TYPE),count=$(GPU_PER_NODE) \
 		--service-account=$(GKE_NODE_SERVICE_ACCOUNT_EMAIL) \
 		--zone $(GPU_COMPUTE_ZONE) \
@@ -134,9 +112,9 @@ gke/create/gpus:
 		--enable-autoscaling \
 		--enable-autorepair \
 		--enable-autoupgrade \
-		2> /dev/null \
 		|| echo "GPU node pool already exists."
 	@echo "GPU node pool completion finished."
+	@echo " "
 	@echo " "
 
 # https://cloud.google.com/kubernetes-engine/docs/how-to/gpus#gpu_pool
@@ -155,10 +133,11 @@ gke/destroy/gpus:
 ## Create Service Account used by deepcell
 gke/create/service-account:
 	@echo "Creating GKE service account..."
-	@gcloud iam service-accounts create $(CLUSTER_NAME) --display-name "Deepcell" 2> /dev/null || \
+	@gcloud iam service-accounts create $(CLUSTER_NAME) --display-name "Deepcell" || \
 		echo "No need to create service account; it probably already exists."
-	@gcloud projects add-iam-policy-binding $(CLOUDSDK_CORE_PROJECT) --member serviceAccount:$(GKE_NODE_SERVICE_ACCOUNT_EMAIL) --role roles/storage.admin > /dev/null
+	@gcloud projects add-iam-policy-binding $(CLOUDSDK_CORE_PROJECT) --member serviceAccount:$(GKE_NODE_SERVICE_ACCOUNT_EMAIL) --role roles/storage.admin
 	@echo "GKE service account creation complete."
+	@echo " "
 	@echo " "
 
 ## Delete Service Account used by deepcell
@@ -172,10 +151,11 @@ gke/destroy/service-account:
 ## Create bucket used by deepcell
 gke/create/bucket:
 	@echo "Creating Google Cloud Storage Bucket ${CLOUDSDK_CORE_PROJECT}..."
-	@gsutil mb -p $(CLOUDSDK_CORE_PROJECT) gs://$(CLOUDSDK_BUCKET) 2> /dev/null \
+	@gsutil mb -p $(CLOUDSDK_CORE_PROJECT) gs://$(CLOUDSDK_BUCKET) \
 		|| echo "Bucket ${CLOUDSDK_CODE_PROJECT} already exists. No need to create that bucket."
-	@gsutil acl ch -u $(GKE_NODE_SERVICE_ACCOUNT_EMAIL):O gs://$(CLOUDSDK_BUCKET) 2> /dev/null
+	@-gsutil acl ch -u $(GKE_NODE_SERVICE_ACCOUNT_EMAIL):O gs://$(CLOUDSDK_BUCKET)
 	@echo "Google Cloud Storage Bucket creation finished."
+	@echo " "
 	@echo " "
 
 ## Destroy bucket used by deepcell
@@ -186,9 +166,10 @@ gke/destroy/bucket:
 gke/deploy/helm:
 	@echo "Deploying kubernetes resources..."
 	@kubectl create serviceaccount --namespace kube-system tiller 2> /dev/null || echo "Kubernetes already appears to be deployed."
-	@kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:tiller 2> /dev/null || :
-	@helm init --service-account tiller --upgrade --wait &> /dev/null || :
+	@-kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:tiller
+	@-helm init --service-account tiller --upgrade --wait
 	@echo "Kubernetes resource deployment finished."
+	@echo " "
 	@echo " "
 
 gke/destroy/helm:
@@ -202,6 +183,7 @@ gke/deploy/nvidia:
 	@kubectl apply -f https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/stable/nvidia-driver-installer/cos/daemonset-preloaded.yaml || \
 		echo "These drivers are not being installed. They may already be installed."
 	@echo "NVIDIA GPU driver deployment finished."
+	@echo " "
 	@echo " "
 
 ## Create Cluster

--- a/conf/tasks/Makefile.helm
+++ b/conf/tasks/Makefile.helm
@@ -1,4 +1,5 @@
 helm/create/tiller:
+	@echo "Deplying Kubernetes resources using Helm...
 	helm init --upgrade --wait
 
 helm/create/all: \

--- a/conf/tasks/Makefile.helmfile
+++ b/conf/tasks/Makefile.helmfile
@@ -1,6 +1,7 @@
 helmfile/create/all:
 	@echo " "
 	@echo "Syncing all Kubernetes resources using helmfiles..."
-	@helmfile sync &> /dev/null || echo "Services couldn't be synced."
+	@helmfile sync || echo "Services couldn't be synced."
 	@echo "Helmfile deployment finished."
+	@echo " "
 	@echo " "

--- a/conf/tasks/Makefile.helmfile
+++ b/conf/tasks/Makefile.helmfile
@@ -1,3 +1,6 @@
 helmfile/create/all:
-	@helmfile sync
-	@echo "Helmfiles deployed"
+	@echo " "
+	@echo "Syncing all Kubernetes resources using helmfiles..."
+	@helmfile sync &> /dev/null || echo "Services couldn't be synced."
+	@echo "Helmfile deployment finished."
+	@echo " "

--- a/conf/tasks/Makefile.kops
+++ b/conf/tasks/Makefile.kops
@@ -15,7 +15,9 @@ kops/create/ssh-key:
 
 ## Destroy SSH key for Kops cluster
 kops/destroy/ssh-key:
-	@rm -f $(SSH_KEY) $(SSH_PUBLIC_KEY)
+	@echo "Deleting cluster SSH key pair."
+	@rm -f $(SSH_KEY) $(SSH_PUBLIC_KEY) || echo "It looks like no SSH key pair was found in the first place?"
+	@echo " "
 
 ## Provision kops cluster
 kops/create/cluster:
@@ -76,16 +78,21 @@ kops/create/all: \
   kops/create/$(CLOUD_PROVIDER) \
   kops/create/gpu-nodes 
 	@echo "Kops created"
+	@echo " "
 
 ## Destroy kops cluster
 kops/destroy/cluster:
-	kops delete cluster --name $(KOPS_CLUSTER_NAME) --yes
+	@echo "Destroying kops cluster ${KOPS_CLUSTER_NAME}."
+	@kops delete cluster --name $(KOPS_CLUSTER_NAME) --yes 2> /dev/null || \
+		echo "Apparently, the cluster is already nonexistent."
+	@echo " "
 
 ## Destroy all kops resources
 kops/destroy/all: \
   kops/destroy/cluster \
   kops/destroy/ssh-key
 	@echo "Kops destroyed"
+	@echo " "
 
 ## Wait for kops cluster to come online
 kops/wait:

--- a/conf/tasks/Makefile.kops
+++ b/conf/tasks/Makefile.kops
@@ -9,7 +9,9 @@ kops/create/ssh-key:
 	    echo "At the very least the CACHE_PATH directory, " $(CACHE_PATH) ", does not exist."; \
 	    exit 1; \
 	fi
-	@ssh-keygen -t rsa -f $(SSH_KEY) -N ""
+	@echo "Generating public/private RSA key pair..."
+	@ssh-keygen -t rsa -f $(SSH_KEY) -N "" > /dev/null || echo "Nevermind. The keys probably already exist."
+	@echo " "
 
 ## Destroy SSH key for Kops cluster
 kops/destroy/ssh-key:
@@ -17,27 +19,50 @@ kops/destroy/ssh-key:
 
 ## Provision kops cluster
 kops/create/cluster:
-	kops create cluster \
+	@echo "Requisitioning cloud resources using kops (Kubernetes Operations)..."
+	@echo "Using the following command:"
+	@echo "  kops create cluster \\"
+	@echo "    --name $(KOPS_CLUSTER_NAME) \\"
+	@echo "    --zones $(KOPS_AVAILABILITY_ZONES) \\"
+	@echo "    --cloud $(CLOUD_PROVIDER) \\"
+	@echo "    --master-size $(MASTER_MACHINE_TYPE) \\"
+	@echo "    --node-size $(NODE_MACHINE_TYPE) \\"
+	@echo "    --ssh-public-key $(SSH_PUBLIC_KEY) \\"
+	@echo "    --yes"
+	@kops create cluster \
 	  --name $(KOPS_CLUSTER_NAME) \
 	  --zones $(KOPS_AVAILABILITY_ZONES) \
 	  --cloud $(CLOUD_PROVIDER)  \
 	  --master-size $(MASTER_MACHINE_TYPE) \
 	  --node-size $(NODE_MACHINE_TYPE) \
 	  --ssh-public-key $(SSH_PUBLIC_KEY) \
-	  --yes
+	  --yes \
+	  2> /dev/null || echo "Well, I guess this cluster already exists, so we're not recreating it."
+	@echo " "
 
 kops/create/aws:
-	kops get cluster -o yaml > /tmp/cluster-template.yaml
-	yq merge -x /tmp/cluster-template.yaml patches/aws.yaml > /tmp/cluster.yaml
-	kops replace -f /tmp/cluster.yaml
-	kops update cluster --yes
+	@echo "Briefly restarting the AWS cluster in order to add some necessary permissions to it..."
+	@kops get cluster -o yaml > /tmp/cluster-template.yaml
+	@yq merge -x /tmp/cluster-template.yaml patches/aws.yaml > /tmp/cluster.yaml
+	@kops replace -f /tmp/cluster.yaml
+	@kops update cluster --yes &> /dev/null
+	@echo "Done."
+	@echo " "
 
 ## Provision GPU instance group
+kops/create/gpu-nodes: GPU_NODES_EXIST = $(shell sh -c "kops get ig | grep 'gpu-nodes'" )
 kops/create/gpu-nodes:
-	kops create ig gpu-nodes -o yaml --dry-run > /tmp/gpu-nodes-template.yaml
-	yq merge -x /tmp/gpu-nodes-template.yaml patches/gpu-nodes.yaml > /tmp/gpu-nodes.yaml
-	kops create -f /tmp/gpu-nodes.yaml
-	kops update cluster --yes
+	@echo "Creating GPU node pool."
+	@echo "(Not requisitioning GPUs now, just granting Kubernetes the ability to get them once they're needed.)"
+	@if [[ -z "${GPU_NODES_EXIST}" ]]; then \
+		kops create ig gpu-nodes -o yaml --dry-run > /tmp/gpu-nodes-template.yaml; \
+		yq merge -x /tmp/gpu-nodes-template.yaml patches/gpu-nodes.yaml > /tmp/gpu-nodes.yaml; \
+		kops create -f /tmp/gpu-nodes.yaml; \
+		kops update cluster --yes; \
+	else \
+		echo "GPU node pool already exists. Moving on."; \
+	fi
+	@echo " "
 
 ## Destroy GPU instance group
 kops/destroy/gpu-nodes:

--- a/conf/tasks/Makefile.kops
+++ b/conf/tasks/Makefile.kops
@@ -10,27 +10,22 @@ kops/create/ssh-key:
 	    exit 1; \
 	fi
 	@echo "Generating public/private RSA key pair..."
-	@ssh-keygen -t rsa -f $(SSH_KEY) -N "" > /dev/null || echo "Nevermind. The keys probably already exist."
+	@ssh-keygen -t rsa -f $(SSH_KEY) -N "" || echo "Nevermind. The keys probably already exist."
+	@echo " "
 	@echo " "
 
 ## Destroy SSH key for Kops cluster
 kops/destroy/ssh-key:
 	@echo "Deleting cluster SSH key pair."
 	@rm -f $(SSH_KEY) $(SSH_PUBLIC_KEY) || echo "It looks like no SSH key pair was found in the first place?"
+	@echo "Cluster SSH key pair deletion finished."
+	@echo " "
 	@echo " "
 
 ## Provision kops cluster
 kops/create/cluster:
 	@echo "Requisitioning cloud resources using kops (Kubernetes Operations)..."
 	@echo "Using the following command:"
-	@echo "  kops create cluster \\"
-	@echo "    --name $(KOPS_CLUSTER_NAME) \\"
-	@echo "    --zones $(KOPS_AVAILABILITY_ZONES) \\"
-	@echo "    --cloud $(CLOUD_PROVIDER) \\"
-	@echo "    --master-size $(MASTER_MACHINE_TYPE) \\"
-	@echo "    --node-size $(NODE_MACHINE_TYPE) \\"
-	@echo "    --ssh-public-key $(SSH_PUBLIC_KEY) \\"
-	@echo "    --yes"
 	@kops create cluster \
 	  --name $(KOPS_CLUSTER_NAME) \
 	  --zones $(KOPS_AVAILABILITY_ZONES) \
@@ -39,7 +34,9 @@ kops/create/cluster:
 	  --node-size $(NODE_MACHINE_TYPE) \
 	  --ssh-public-key $(SSH_PUBLIC_KEY) \
 	  --yes \
-	  2> /dev/null || echo "Well, I guess this cluster already exists, so we're not recreating it."
+	  || echo "Well, I guess this cluster already exists, so we're not recreating it."
+	@echo "Cloud resource requisition finished."
+	@echo " "
 	@echo " "
 
 kops/create/aws:
@@ -47,8 +44,9 @@ kops/create/aws:
 	@kops get cluster -o yaml > /tmp/cluster-template.yaml
 	@yq merge -x /tmp/cluster-template.yaml patches/aws.yaml > /tmp/cluster.yaml
 	@kops replace -f /tmp/cluster.yaml
-	@kops update cluster --yes &> /dev/null
-	@echo "Done."
+	@kops update cluster --yes || echo "Restart and update didn't happen."
+	@echo "Permission addition finished."
+	@echo " "
 	@echo " "
 
 ## Provision GPU instance group
@@ -64,6 +62,8 @@ kops/create/gpu-nodes:
 	else \
 		echo "GPU node pool already exists. Moving on."; \
 	fi
+	@echo "GPU node pool creation finished."
+	@echo " "
 	@echo " "
 
 ## Destroy GPU instance group
@@ -85,6 +85,8 @@ kops/destroy/cluster:
 	@echo "Destroying kops cluster ${KOPS_CLUSTER_NAME}."
 	@kops delete cluster --name $(KOPS_CLUSTER_NAME) --yes 2> /dev/null || \
 		echo "Apparently, the cluster is already nonexistent."
+	@echo "Kops cluster destruction finished."
+	@echo " "
 	@echo " "
 
 ## Destroy all kops resources

--- a/conf/tasks/Makefile.kubectl
+++ b/conf/tasks/Makefile.kubectl
@@ -1,6 +1,10 @@
 ## Provision RBAC cluster role binding
 kubectl/create/rbac:
-	@kubectl create clusterrolebinding add-on-cluster-admin --clusterrole=cluster-admin --serviceaccount=kube-system:default
+	@echo " "
+	@echo "Finalizing Kubernetes RBAC roles and bindings."
+	@kubectl create clusterrolebinding add-on-cluster-admin --clusterrole=cluster-admin --serviceaccount=kube-system:default 2> /dev/null || \
+		echo "Kubernetes RBAC binding is already under control. Moving on."
+	@echo " "
 
 ## Provision cluster autoscaler
 kubectl/create/autoscaler:

--- a/conf/tasks/Makefile.kubectl
+++ b/conf/tasks/Makefile.kubectl
@@ -3,7 +3,9 @@ kubectl/create/rbac:
 	@echo " "
 	@echo "Finalizing Kubernetes RBAC roles and bindings."
 	@kubectl create clusterrolebinding add-on-cluster-admin --clusterrole=cluster-admin --serviceaccount=kube-system:default 2> /dev/null || \
-		echo "Kubernetes RBAC binding is already under control. Moving on."
+		echo "Kubernetes RBAC binding is already under control. No changes made."
+	@echo "Kubernetes RBAC roles creation and binding finished."
+	@echo " "
 	@echo " "
 
 ## Provision cluster autoscaler


### PR DESCRIPTION
This branch is meant to fix issue #26.

Now, cluster creation and destruction process are all fault-tolerant, meaning that, if an earlier step in the process fails (say, you're starting up a cluster, but a bucket with the name of the cluster already exists, perhaps because you aborted the startup process a second ago and are now retrying it), the later steps in the process will still be executed, meaning that the cluster could still potentially be created/destroyed as intended.