### PR TITLE
the autoscaler should now be able to autoscale the training job

### DIFF
--- a/conf/charts/autoscaler/templates/clusterrole.yaml
+++ b/conf/charts/autoscaler/templates/clusterrole.yaml
@@ -4,5 +4,5 @@ metadata:
   name: {{ .Values.app_name }}
 rules:
   - apiGroups: ["*"]
-    resources: ["deployments"]
+    resources: ["deployments", "job"]
     verbs: ["get", "list", "update"]

--- a/conf/charts/autoscaler/templates/clusterrole.yaml
+++ b/conf/charts/autoscaler/templates/clusterrole.yaml
@@ -4,5 +4,5 @@ metadata:
   name: {{ .Values.app_name }}
 rules:
   - apiGroups: ["*"]
-    resources: ["deployments", "job"]
+    resources: ["deployments", "jobs"]
     verbs: ["get", "list", "update"]

--- a/conf/helmfile.d/0200.autoscaler.yaml
+++ b/conf/helmfile.d/0200.autoscaler.yaml
@@ -38,4 +38,4 @@ releases:
         INTERVAL: "5"
         REDIS_HOST: "redis-master"
         REDIS_PORT: "6379"
-        AUTOSCALING: "0|1|5|deepcell|deployment|predict|tf-serving-deployment; 0|1|5|deepcell|deployment|predict|redis-consumer-deployment; 0|1|5|deepcell|deployment|predict|redis-consumer-post-deployment; 0|1|5|deepcell|deployment|predict|redis-consumer    -pre-deployment; 0|4|1|deepcell|job|train|training-job"
+        AUTOSCALING: "0|1|5|deepcell|deployment|predict|tf-serving-deployment; 0|1|5|deepcell|deployment|predict|redis-consumer-deployment; 0|1|5|deepcell|deployment|predict|redis-consumer-post-deployment; 0|1|5|deepcell|deployment|predict|redis-consumer-pre-deployment; 0|4|1|deepcell|job|train|training-job"

--- a/conf/helmfile.d/0200.autoscaler.yaml
+++ b/conf/helmfile.d/0200.autoscaler.yaml
@@ -30,7 +30,7 @@ releases:
       deployment_name: "autoscaler-deployment"
       replicas: 1
       image_name: "vanvalenlab/kiosk-autoscaler"
-      image_version: "0.1"
+      image_version: "0.1.1"
       container_name: "autoscaler-container"
       service_account_name: "autoscaler-service-account"
       env:
@@ -38,4 +38,4 @@ releases:
         INTERVAL: "5"
         REDIS_HOST: "redis-master"
         REDIS_PORT: "6379"
-        AUTOSCALING: "0|1|5|deepcell|tf-serving-deployment; 0|1|5|deepcell|redis-consumer-deployment; 0|1|5|deepcell|redis-consumer-post-deployment; 0|1|5|deepcell|redis-consumer-pre-deployment"
+        AUTOSCALING: "0|1|5|deepcell|deployment|predict|tf-serving-deployment; 0|1|5|deepcell|deployment|predict|redis-consumer-deployment; 0|1|5|deepcell|deployment|predict|redis-consumer-post-deployment; 0|1|5|deepcell|deployment|predict|redis-consumer    -pre-deployment; 0|4|1|deepcell|job|train|training-job"


### PR DESCRIPTION
This branch, in conjunction with the `training-pod-support` branch of the `vanvalenlab/kiosk-autoscaler` repository, allows the autoscaler to scale the `training-job` Kubernetes job and, in general, to scale prediction and training resources separately from one another.