### PR TITLE
Cluster pause and restart functionality

### DIFF
--- a/conf/tasks/Makefile.kops
+++ b/conf/tasks/Makefile.kops
@@ -101,3 +101,32 @@ kops/wait:
 	@echo "Waiting for kops cluster to come online..."
 	@time wait-for-kops
 
+## Pause kops cluster
+kops/pause: \
+  kops/get_instance_groups
+	@for (( i=1; i<${igs_array_length}; i++ )); do \
+	  echo "${igs_array[i]}"; \
+	  export tmp_ig="${igs_array[i]}"; \
+	  kops get ig ${tmp_ig} -o yaml > ./${tmp_ig}_old.yaml; \
+	  cat  ./${tmp_ig}_old.yaml | sed 's/\(min\|max\)Size: [[:digit:]]\+/\1Size: 0/' > ./${tmp_ig}_new.yaml; \
+	  echo "-----"; \
+	  kops replace -f ./${tmp_ig}_new.yaml; \
+	done
+	@kops update cluster --yes
+
+## Restart paused cluster
+kops/restart: \
+  kops/get_instance_groups
+	@for (( i=1; i<${igs_array_length}; i++ )); do \
+	  echo "${igs_array[i]}"; \
+	  export tmp_ig="${igs_array[i]}"; \
+	  echo "-----"; \
+	  kops replace -f ./${tmp_ig}_old.yaml; \
+	done
+	@kops update cluster --yes
+
+## Get instance groups of kops cluster and assign them to an array
+kops/get_instance_groups:
+	@export igs=$(kops get ig | awk '{print $1}')
+	@IFS=${'\n'} read -rd '' -a igs_array <<< "${igs}"
+	@export igs_array_length="${#igs_array[@]}"

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -82,7 +82,7 @@ function menu() {
   cloud_providers[${CLOUD_PROVIDER:-none}]="(active)"
   value=$(dialog --clear  --help-button --backtitle "${BRAND}" \
             --title "[ M A I N - M E N U ]" \
-            --menu "${header_text[*]}" 17 50 7 \
+            --menu "${header_text[*]}" 19 50 9 \
                 "AWS"     "Configure Amazon ${cloud_providers[aws]}" \
                 "GKE"     "Configure Google ${cloud_providers[gke]}" \
 		"Create"  "Create ${CLOUD_PROVIDER^^} Cluster" \
@@ -115,8 +115,8 @@ function configure_aws() {
   
   make create_cache_path
   printenv | grep -e CLOUD_PROVIDER > ${CACHE_PATH}/env
-  printenv | grep -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_S3_BUCKET -e NAMESPACE > ${CACHE_PATH}/env.aws
-  #printenv | grep -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_S3_BUCKET -e NAMESPACE -e KOPS_CLUSTER_NAME -e KOPS_DNS_ZONE -e KOPS_STATE_STORE > ${CACHE_PATH}/env.aws
+  #printenv | grep -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_S3_BUCKET -e NAMESPACE > ${CACHE_PATH}/env.aws
+  printenv | grep -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_S3_BUCKET -e NAMESPACE -e KOPS_CLUSTER_NAME -e KOPS_DNS_ZONE -e KOPS_STATE_STORE > ${CACHE_PATH}/env.aws
 }
 
 function configure_gke() {
@@ -146,6 +146,14 @@ function destroy() {
   tailcmd "Destroy Cluster" "---COMPLETE--" make destroy
 }
 
+function pause_cluster() {
+    tailcmd "Pause Cluster" "---COMPLETE---" make kops/pause
+}
+
+function restart_cluster() {
+    tailcmd "Restart Cluster" "---COMPLETE---" make kops/restart
+}
+
 function view() {
   local title="Deepcell Cluster Address"
   if [ -f ./cluster_address ]; then
@@ -173,6 +181,8 @@ function main() {
       "AWS") configure_aws ;;
       "GKE") configure_gke ;;
       "Create") create ;;
+      "Pause") pause_cluster ;;
+      "Restart") restart_cluster ;;
       "Destroy") destroy;;
       "View") view;;
       "Exit") break ;;


### PR DESCRIPTION
This branch should address both #22 and #62.

It looks like this functionality is going to have to be completely different for AWS and GKE.

AWS:
I haven't found a way to put EC2 instances into the "stop" (vs. "terminated") state. If you can find anything about that, @willgraf or @vanvalen, let me know. for now, I'll just move ahead with temrinating instances and restarting them.

Currently, I can terminate them and restart instances at will. Startup takes the same amount of time as normal (~5 minutes) but the big potential advantages or pausing/restarting vs destroying/recreating are 1) users could keep their Redis database between a pause/restart (is that even useful?), 2) the user doesn't have to worry about reconfiguring the cluster again, and 3) restart times can be much less than recreation times, once you take into account that the GPUs will be requisitioned at the same time as all other cluster resources. (I've yet to verify restart times with GPUs, though.)

AWS TODO:
- [ ] Verify time savings in case where GPU instances will be requisitioned.
- [ ] Verify that Redis database persists across pause/restart cycle.
- [ ] Investigate what happens to computations that are ongoing when a pause is initiated. We'd like to handle pauses gracefully and not interrupt any ongoing computations.
- [x] Make sure the KOPS_CLUSTER_NAME variable is being set.

GKE:
Further research needed. We're not using kops, so we'll have to do something via the `gcloud` command line interface.

General TODO:
- [ ] Combine two kiosk menu items into one whose text changes appropriately.