### PR TITLE
allowing tf-serving pods to schedule appropriately with any GPU

### DIFF
--- a/conf/helmfile.d/0310.tf-serving.yaml
+++ b/conf/helmfile.d/0310.tf-serving.yaml
@@ -38,9 +38,9 @@ releases:
       service_type: "ClusterIP"
       nodeSelector:
 {{ if eq (env "CLOUD_PROVIDER" | default "aws") "aws" }}
-        beta.kubernetes.io/instance-type: "p2.xlarge"
+        beta.kubernetes.io/instance-type: '{{ env "AWS_GPU_MACHINE_TYPE" | default "p2.xlarge" }}'
 {{ else }}
-        cloud.google.com/gke-accelerator: "nvidia-tesla-k80"
+        cloud.google.com/gke-accelerator: '{{ env "GPU_TYPE" | default "nvidia-tesla-k80" }}'
 {{ end }}
       env:
         RPC_PORT: "8500"


### PR DESCRIPTION
Specifying GPU type in `0310.tf-serving.yaml` helmfile using an environmental variable now, so that the tf-serving pod will be able to schedule even when we choose non-default GPU types.