### PR TITLE
Kiosk branding changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ ENV DOCKER_TAG="latest"
 
 # Geodesic banner
 ENV BANNER="deepcell"
+ENV BANNER_FONT="Electronic.flf"
 
 # Disable cloudposse motd
 ENV MOTD_URL=""

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV DOCKER_TAG="latest"
 
 # Geodesic banner
 ENV BANNER="deepcell"
-ENV BANNER_FONT="Electronic.flf"
+ENV BANNER_FONT="Larry 3D 2.flf"
 
 # Disable cloudposse motd
 ENV MOTD_URL=""

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -24,7 +24,7 @@ function retval() {
 function msgbox() {
   local title=$1
   local message=$2
-  dialog --backtitle "$BRAND" --title "$title" --clear --msgbox "$message" 10 41
+  dialog --backtitle "$BRAND" --title "$title" --clear --msgbox "$message" 12 60
   retval $?
 }
 
@@ -222,7 +222,12 @@ function view() {
 
 function main() {
   export MENU=true
-  msgbox "Welcome!" "Welcome to the Deepcell Kiosk"
+  msgbox "Welcome!" \
+	 "Welcome to the Deepcell Kiosk!
+
+This Kiosk was developed by the Van Valen Lab at the California Institute of Technology.
+
+https://vanvalenlab.caltech.edu"
 
   while true; do
     ACTION=$(menu)


### PR DESCRIPTION
I 
1) changed the greeting text
and
2) changed the font of the colorful ASCII graphic at the top of the shell inside the kiosk menu.

Changing the greeting text was simple.

However, changing the ASCII characters in the Deepcell logo that displays when one drops to the shell turned into an interesting quest. The program that handles the logo display is called `figurine`. Figurine has a lot of different ASCII fonts to choose form, and those are what control which characters are used. To generate a really cool display of all possible Deepcell logos, drop to the shell inside a kiosk and execute the following:
```
export FONT_LIST=$(figurine -l)
IFS=$'\n' read -r -d '' -a FONT_LIST_ARRAY <<< "$FONT_LIST"
for i in "${FONT_LIST_ARRAY[@]}"; do echo " "; echo $i; figurine -f "$i" Deepcell; echo " "; done
```

So many cool fonts, including:
`Tiles.flf`
`Speed.flf`
`Larry 3D.flf`
`Electronic.flf`
`Def Leppard.flf`
`Dos Rebel.flf`
`Cyberlarge.flf`
`3D.flf`

For my part, I'm going to pick `Electronic.flf`, but I'd like both @willgraf and @vanvalen to review this pull request, so we can be sure we end up with the absolute coolest font possible.

Fixes #33.


Also, @osterman I couldn't find any documentation for `figurine` online. Does the project have a homepage, or does it just mysteriously get distributed with Alpine?