### PR TITLE
added toleration for gpu nodes

### DIFF
--- a/conf/charts/training/templates/job.yaml
+++ b/conf/charts/training/templates/job.yaml
@@ -21,6 +21,10 @@ spec:
         {{ $name }}: {{ $value | quote }}
 {{- end }}
 {{- end }}
+      tolerations:
+      - key: "nvidia.com/gpu"
+        operator: "Exists"
+        effect: "NoSchedule"
       containers:
       - name: {{ .Values.container_name }}
         image: {{ .Values.image_name }}:{{ .Values.image_version }}


### PR DESCRIPTION
I added a toleration for `nvidia.com/gpu=NoSchedule` to the `training` deployment. I learned, from inspecting the logs of the `cluster-autoscaler` pod that a lack of tolerations was preventing the training jobs from scheduling on the GPU nodes. After checking the taints of the GPU nodes, the needed toleration was easy to figure out.

Fixes #71.