### PR TITLE
added TPU functionality for training

### DIFF
--- a/conf/charts/training/templates/job.yaml
+++ b/conf/charts/training/templates/job.yaml
@@ -13,7 +13,11 @@ spec:
       labels:
         app: {{ .Values.app_name }}
       annotations:
-        tf-version.cloud-tpus.google.com: "1.9"
+{{- range $name, $value := .Values.annotations }}
+{{- if not ( empty $value) }}
+        {{ $name }}: {{ $value | quote }}
+{{- end }}
+{{- end }}
     spec:
       restartPolicy: Never
       nodeSelector:
@@ -32,7 +36,11 @@ spec:
         imagePullPolicy: "Always"
         resources:
           limits:
-            cloud-tpus.google.com/v2: 8
+{{- range $name, $value := .Values.limits }}
+{{- if not ( empty $value) }}
+        {{ $name }}: {{ $value | quote }}
+{{- end }}
+{{- end }}
         ports:
         - containerPort: {{ .Values.job_port }}
         env:

--- a/conf/charts/training/templates/job.yaml
+++ b/conf/charts/training/templates/job.yaml
@@ -12,6 +12,8 @@ spec:
       name: {{ .Values.job_name }}
       labels:
         app: {{ .Values.app_name }}
+      annotations:
+        tf-version.cloud-tpus.google.com: "1.9"
     spec:
       restartPolicy: Never
       nodeSelector:
@@ -30,7 +32,7 @@ spec:
         imagePullPolicy: "Always"
         resources:
           limits:
-            nvidia.com/gpu: 1
+            cloud-tpus.google.com/v2: 8
         ports:
         - containerPort: {{ .Values.job_port }}
         env:

--- a/conf/charts/training/values.yaml
+++ b/conf/charts/training/values.yaml
@@ -13,10 +13,17 @@ service_name: "training-service"
 service_port: 7241
 service_type: "ClusterIP"
 
+annotations:
+  #  tf-version.cloud-tpus.google.com: "1.9"
+
 nodeSelector:
   #  cloud.google.com/gke-accelerator: "nvidia-tesla-k80"
   #  beta.kubernetes.io/instance-type: "p2.xlarge"
 
+limits:
+  #  cloud-tpus.google.com/v2: 8
+
+  
 # secrets.yaml and hemlfile.d/training.yaml
 env:
   CLOUD_PROVIDER: "aws"

--- a/conf/helmfile.d/0400.training-job.yaml
+++ b/conf/helmfile.d/0400.training-job.yaml
@@ -36,12 +36,12 @@ releases:
       service_name: "training-service"
       service_port: 7241
       service_type: "ClusterIP"
-      nodeSelector:
-{{ if eq (env "CLOUD_PROVIDER" | default "aws") "aws" }}
-        beta.kubernetes.io/instance-type: '{{ env "AWS_GPU_MACHINE_TYPE" | default "p2.xlarge" }}'
-{{ else }}
-        cloud.google.com/gke-accelerator: '{{ env "GPU_TYPE" | default "nvidia-tesla-k80" }}'
-{{ end }}
+#      nodeSelector:
+#{{ if eq (env "CLOUD_PROVIDER" | default "aws") "aws" }}
+#        beta.kubernetes.io/instance-type: '{{ env "AWS_GPU_MACHINE_TYPE" | default "p2.xlarge" }}'
+#{{ else }}
+#        cloud.google.com/gke-accelerator: '{{ env "GPU_TYPE" | default "nvidia-tesla-k80" }}'
+#{{ end }}
       env:
         CLOUD_PROVIDER: '{{ env "CLOUD_PROVIDER" | default "aws" }}'
         DEBUG: "True"

--- a/conf/helmfile.d/0400.training-job.yaml
+++ b/conf/helmfile.d/0400.training-job.yaml
@@ -27,6 +27,12 @@ releases:
   version: "0.1.0"
   values:
     - app_name: "training"
+      annotations:
+{{ if eq (env "CLOUD_PROVIDER" | default "aws") "gke" }}
+  {{ if eq (env "GPUS_OR_TPUS" | "GPUs") "TPUs" }}
+        tf-version.cloud-tpus.google.com: "1.9"
+  {{ end }}
+{{ end }}
       parallelism: 1
       image_name: "vanvalenlab/kiosk-training"
       image_tag: "0.1"
@@ -36,12 +42,20 @@ releases:
       service_name: "training-service"
       service_port: 7241
       service_type: "ClusterIP"
-#      nodeSelector:
-#{{ if eq (env "CLOUD_PROVIDER" | default "aws") "aws" }}
-#        beta.kubernetes.io/instance-type: '{{ env "AWS_GPU_MACHINE_TYPE" | default "p2.xlarge" }}'
-#{{ else }}
-#        cloud.google.com/gke-accelerator: '{{ env "GPU_TYPE" | default "nvidia-tesla-k80" }}'
-#{{ end }}
+      nodeSelector:
+{{ if eq (env "CLOUD_PROVIDER" | default "aws") "aws" }}
+        beta.kubernetes.io/instance-type: '{{ env "AWS_GPU_MACHINE_TYPE" | default "p2.xlarge" }}'
+{{ else }}
+  {{ if eq (env "GPUS_OR_TPUS" | "GPUs") "GPUs" }}
+        cloud.google.com/gke-accelerator: '{{ env "GPU_TYPE" | default "nvidia-tesla-k80" }}'
+  {{ end }}
+{{ end }}
+      limits:
+{{ if eq (env "CLOUD_PROVIDER" | default "aws") "gke" }}
+  {{ if eq (env "GPUS_OR_TPUS" | "GPUs") "TPUs" }}
+        cloud-tpus.google.com/v2: 8
+  {{ end }}
+{{ end }}
       env:
         CLOUD_PROVIDER: '{{ env "CLOUD_PROVIDER" | default "aws" }}'
         DEBUG: "True"

--- a/conf/tasks/Makefile.gke
+++ b/conf/tasks/Makefile.gke
@@ -46,6 +46,29 @@ gke/create/project:
 gke/destroy/project:
 	@gcloud projects delete $(CLOUDSDK_CORE_PROJECT)
 
+## Create a new GKE cluster with TPUs enabled
+gke/create/cluster/tpu:
+	@echo "Creating GKE cluster..."
+	@echo "Using the following command: "
+	@gcloud components install beta --quiet
+	@gcloud config set project ${PROJECT}
+	@gcloud config set compute/zone ${GKE_COMPUTE_ZONE} 
+	gcloud beta container clusters create $(CLUSTER_NAME) \
+		--zone=$(GKE_COMPUTE_ZONE) \
+		--max-nodes=$(NODE_MAX_SIZE) \
+		--min-nodes=$(NODE_MIN_SIZE) \
+		--machine-type=$(GKE_MACHINE_TYPE) \
+		--cluster-version $(KUBERNETES_VERSION) \
+		--enable-autoscaling \
+		--enable-autoupgrade \
+		--scopes=cloud-platform \
+		--enable-ip-alias \
+		--enable-tpu \
+		|| echo "Apparently, the cluster already exists."
+	@echo "GKE cluster creation complete."
+	@echo " "
+	@echo " "
+
 ## Create a new GKE cluster
 gke/create/cluster:
 	@echo "Creating GKE cluster..."
@@ -190,7 +213,7 @@ gke/deploy/nvidia:
 ## Create Cluster
 gke/create/all: \
 	gke/create/service-account \
-	gke/create/cluster \
+	gke/create/cluster/tpu \
 	gke/create/gpus \
 	gke/create/bucket \
 	gke/deploy/helm \

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -210,11 +210,14 @@ function configure_gke() {
 	  return 0
   fi
 
+  local base_box_height=7
+  local total_lines=$(($base_box_height+2))
+  export GPUS_OR_TPUS=$(radiobox "Google Cloud" "Would you like to use GPUs or TPUs in your cluster?" \
+      $total_lines 60 2 "GPUs _ ON TPUs _ OFF")
   gcloud config set project ${PROJECT}
   local gpus_in_region=$(gcloud compute accelerator-types list | \
 	  grep ${GKE_COMPUTE_ZONE} | awk '{print $1 " _ OFF"}')
   local gpus_with_default=${gpus_in_region/nvidia-tesla-k80 _ OFF/nvidia-tesla-k80 _ ON}
-  local base_box_height=7
   local selector_box_lines=$(echo "${gpus_in_region}" | tr -cd '\n' | wc -c)
   local total_lines=$(($base_box_height + $selector_box_lines))
   export GPU_TYPE=$(radiobox "Google Cloud" \


### PR DESCRIPTION
Adding TPU functionality for GKE.

- [x] Enable TPU for training
- [ ] Enable TPU for prediction
- [ ] Get TPUs to work with service-accounts, rather than `scope=cloud-platform`
- [ ] Make sure Tensorboard works with TPUs during training
- [ ] give user option to choose TPUs vs GPUs and edit helmfiles to observe this choice

Changes for deepcell:
- [ ] add TPU wrapper where appropriate
- [ ] implement float16
- [ ] fix error below