### PR TITLE
remove AWS_REGION from kiosk-training definition

### DIFF
--- a/conf/charts/training/values.yaml
+++ b/conf/charts/training/values.yaml
@@ -26,7 +26,6 @@ env:
   REDIS_HOST: "redis-master"
   REDIS_PORT: "6379"
   STATUS: "new"
-  AWS_REGION: "us-east-1"
   GKE_COMPUTE_ZONE: "us-west1-b"
 
 secrets_name: "training-env-variables"

--- a/conf/helmfile.d/0400.training-job.yaml
+++ b/conf/helmfile.d/0400.training-job.yaml
@@ -50,7 +50,6 @@ releases:
         REDIS_HOST: "redis-master"
         REDIS_PORT: "6379"
         STATUS: "new"
-        AWS_REGION: "us-east-1"
         GKE_COMPUTE_ZONE: '{{ env "GKE_COMPUTE_ZONE" | default "us-west1-b" }}'
       secrets:
         AWS_ACCESS_KEY_ID: '{{ env "AWS_ACCESS_KEY_ID" | default "NA" }}'

--- a/conf/helmfile.d/0400.training-job.yaml
+++ b/conf/helmfile.d/0400.training-job.yaml
@@ -50,7 +50,7 @@ releases:
         REDIS_HOST: "redis-master"
         REDIS_PORT: "6379"
         STATUS: "new"
-        AWS_REGION: '{{ env "AWS_REGION" | default "us-east-1" }}'
+        AWS_REGION: "us-east-1"
         GKE_COMPUTE_ZONE: '{{ env "GKE_COMPUTE_ZONE" | default "us-west1-b" }}'
       secrets:
         AWS_ACCESS_KEY_ID: '{{ env "AWS_ACCESS_KEY_ID" | default "NA" }}'


### PR DESCRIPTION
The tensorflow file-system can natively use the cloud bucket filesystems with the protocol prefix (e.g. `s3://bucket/key`).  For AWS, the S3 buckets are globally accessible (names must be unique across all regions).

The kiosk is deployed in `AWS_REGION=us-west-2`.  This environment variable is accessible for the training jobs to use.  However, this value of `AWS_REGION` causes the following error:

```
Encountered Unknown AWSError
PermanentRedirect
The bucket you are attempting to access must be addressed using the specified endpoint. Please send all future requests to this endpoint.:
```

This error is resolved by changing `AWS_REGION=us-east-1`, the default region value.  Using `us-east-1`, training works as expected.  I expect this is caused by the global nature of buckets, and using the "global" protocol value of `s3://bucket/key` clashes with the non-default `AWS_REGION` value.

I'm unsure of the ultimate root cause, but setting the AWS_REGION for the kiosk-training to the default region resolves the AWS 301 error seen `kiosk-training`: fixes vanvalenlab/kiosk-training#5.