### PR TITLE
Use ELK namespace for elastic.co pods

### DIFF
--- a/conf/helmfile.d/0500.elasticsearch.yaml
+++ b/conf/helmfile.d/0500.elasticsearch.yaml
@@ -16,12 +16,12 @@ releases:
 #   - [web address of Helm chart's YAML file]
 #
 - name: "elasticsearch"
-  namespace: "deepcell"
+  namespace: "elk"
   labels:
     chart: "elasticsearch"
     component: "elasticsearch"
-    namespace: "deepcell"
     vendor: "vanvalenlab"
+    namespace: "elk"
     default: "true"
   chart: 'stable/elasticsearch'
   version: "1.19.1"

--- a/conf/helmfile.d/0500.elasticsearch.yaml
+++ b/conf/helmfile.d/0500.elasticsearch.yaml
@@ -20,8 +20,8 @@ releases:
   labels:
     chart: "elasticsearch"
     component: "elasticsearch"
-    vendor: "vanvalenlab"
     namespace: "elk"
+    vendor: "elastic.co"
     default: "true"
   chart: 'stable/elasticsearch'
   version: "1.19.1"

--- a/conf/helmfile.d/0510.kibana.yaml
+++ b/conf/helmfile.d/0510.kibana.yaml
@@ -20,8 +20,8 @@ releases:
   labels:
     chart: "kibana"
     component: "kibana"
-    vendor: "vanvalenlab"
     namespace: "elk"
+    vendor: "elastic.co"
     default: "true"
   chart: 'stable/kibana'
   version: "1.5.0"

--- a/conf/helmfile.d/0510.kibana.yaml
+++ b/conf/helmfile.d/0510.kibana.yaml
@@ -16,12 +16,12 @@ releases:
 #   - [web address of Helm chart's YAML file]
 #
 - name: "kibana"
-  namespace: "deepcell"
+  namespace: "elk"
   labels:
     chart: "kibana"
     component: "kibana"
-    namespace: "deepcell"
     vendor: "vanvalenlab"
+    namespace: "elk"
     default: "true"
   chart: 'stable/kibana'
   version: "1.5.0"

--- a/conf/helmfile.d/0520.logstash.yaml
+++ b/conf/helmfile.d/0520.logstash.yaml
@@ -16,12 +16,12 @@ releases:
 #   - [web address of Helm chart's YAML file]
 #
 - name: "logstash"
-  namespace: "deepcell"
+  namespace: "elk"
   labels:
     chart: "logstash"
     component: "logstash"
-    namespace: "deepcell"
     vendor: "vanvalenlab"
+    namespace: "elk"
     default: "true"
   chart: 'stable/logstash'
   version: "1.5.2"

--- a/conf/helmfile.d/0520.logstash.yaml
+++ b/conf/helmfile.d/0520.logstash.yaml
@@ -20,8 +20,8 @@ releases:
   labels:
     chart: "logstash"
     component: "logstash"
-    vendor: "vanvalenlab"
     namespace: "elk"
+    vendor: "elastic.co"
     default: "true"
   chart: 'stable/logstash'
   version: "1.5.2"

--- a/conf/helmfile.d/0530.metricbeat.yaml
+++ b/conf/helmfile.d/0530.metricbeat.yaml
@@ -20,8 +20,8 @@ releases:
   labels:
     chart: "merticbeat"
     component: "metricbeat"
-    vendor: "vanvalenlab"
     namespace: "elk"
+    vendor: "elastic.co"
     default: "true"
   chart: "stable/metricbeat"
   version: "1.0.0"

--- a/conf/helmfile.d/0530.metricbeat.yaml
+++ b/conf/helmfile.d/0530.metricbeat.yaml
@@ -16,12 +16,12 @@ releases:
 #   - [web address of Helm chart's YAML file]
 #
 - name: "metricbeat"
-  namespace: "deepcell"
+  namespace: "elk"
   labels:
     chart: "merticbeat"
     component: "metricbeat"
-    namespace: "deepcell"
     vendor: "vanvalenlab"
+    namespace: "elk"
     default: "true"
   chart: "stable/metricbeat"
   version: "1.0.0"

--- a/conf/helmfile.d/0540.filebeat.yaml
+++ b/conf/helmfile.d/0540.filebeat.yaml
@@ -16,12 +16,12 @@ releases:
 #   - [web address of Helm chart's YAML file]
 #
 - name: "filebeat"
-  namespace: "deepcell"
+  namespace: "elk"
   labels:
     chart: "filebeat"
     component: "filebeat"
-    namespace: "deepcell"
     vendor: "vanvalenlab"
+    namespace: "elk"
     default: "true"
   chart: "stable/filebeat"
   version: "1.0.0"

--- a/conf/helmfile.d/0540.filebeat.yaml
+++ b/conf/helmfile.d/0540.filebeat.yaml
@@ -20,8 +20,8 @@ releases:
   labels:
     chart: "filebeat"
     component: "filebeat"
-    vendor: "vanvalenlab"
     namespace: "elk"
+    vendor: "elastic.co"
     default: "true"
   chart: "stable/filebeat"
   version: "1.0.0"

--- a/conf/helmfile.d/0550.nvidiagpubeat.yaml
+++ b/conf/helmfile.d/0550.nvidiagpubeat.yaml
@@ -16,11 +16,11 @@ releases:
 #   - [web address of Helm chart's YAML file]
 #
 - name: "nvidiagpubeat"
-  namespace: "deepcell"
+  namespace: "elk"
   labels:
     chart: "nvidiagpubeat"
     component: "deepcell"
-    namespace: "deepcell"
+    namespace: "elk"
     vendor: "vanvalenlab"
     default: "true"
   chart: '{{ env "CHARTS_PATH" | default "/conf/charts" }}/nvidiagpubeat'

--- a/conf/helmfile.d/0550.nvidiagpubeat.yaml
+++ b/conf/helmfile.d/0550.nvidiagpubeat.yaml
@@ -19,7 +19,7 @@ releases:
   namespace: "elk"
   labels:
     chart: "nvidiagpubeat"
-    component: "deepcell"
+    component: "nvidiagpubeat"
     namespace: "elk"
     vendor: "vanvalenlab"
     default: "true"


### PR DESCRIPTION
Changed namespace to `elk` for all of the 05xx helmfiles. Also changed the vendor to `elastic.co`. 