### PR TITLE
Feature/upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM cloudposse/build-harness:0.9.0 as build-harness
+FROM cloudposse/build-harness:0.20.0 as build-harness
 
-FROM cloudposse/geodesic:0.32.5
+FROM cloudposse/geodesic:0.91.0
 
 RUN apk add --update dialog libqrencode
 
@@ -53,8 +53,5 @@ COPY rootfs/ /
 
 # Enable the menu
 RUN ln -s /usr/local/bin/menu.sh /etc/profile.d/99.menu.sh
-
-# Grab debugged version of helmfile
-RUN make -C /packages/install helmfile HELMFILE_VERSION=0.40.0
 
 WORKDIR /conf/

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -24,9 +24,6 @@ function retval() {
 function msgbox() {
   local title=$1
   local message=$2
-  # The following two lines constitute a workaround for a bug where the first dialog call after startup fails before user input is possible.
-  dialog --msgbox "Loading..." 12 60
-  sleep 0.5
   dialog --backtitle "$BRAND" --title "$title" --clear --msgbox "$message" 12 60
   retval $?
 }
@@ -446,6 +443,9 @@ function benchmarking() {
 
 function main() {
   export MENU=true
+  # The following two lines constitute a workaround for a bug where the first dialog call after startup fails before user input is possible.
+  dialog --msgbox "Loading..." 12 60
+  sleep 1
   msgbox "Welcome!" \
 	 "Welcome to the Deepcell Kiosk!
 

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -24,6 +24,9 @@ function retval() {
 function msgbox() {
   local title=$1
   local message=$2
+  # The following two lines constitute a workaround for a bug where the first dialog call after startup fails before user input is possible.
+  dialog --msgbox "Loading..." 12 60
+  sleep 0.5
   dialog --backtitle "$BRAND" --title "$title" --clear --msgbox "$message" 12 60
   retval $?
 }

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -444,8 +444,7 @@ function benchmarking() {
 function main() {
   export MENU=true
   # The following two lines constitute a workaround for a bug where the first dialog call after startup fails before user input is possible.
-  dialog --msgbox "Loading..." 12 60
-  sleep 1
+  dialog --msgbox "Loading..." 12 60 --sleep 1
   msgbox "Welcome!" \
 	 "Welcome to the Deepcell Kiosk!
 


### PR DESCRIPTION
After getting over a strange error where the first call to `dialog` upon startup would immediately return with code `255`, the rest of the kiosk seems to be working fine with the new version of `geodesic`.