### PR TITLE
change namespace to `kube-system` and change vendor to openvpn.

### DIFF
--- a/conf/helmfile.d/9999.openvpn.yaml
+++ b/conf/helmfile.d/9999.openvpn.yaml
@@ -16,12 +16,12 @@ releases:
 #   - https://github.com/helm/charts/stable/openvpn
 #
 - name: "openvpn"
-  namespace: "deepcell"
+  namespace: "kube-system"
   labels:
     chart: "openvpn"
     component: "openvpn"
-    namespace: "deepcell"
-    vendor: "vanvalenlab"
+    namespace: "kube-system"
+    vendor: "openvpn"
     default: "true"
   chart: 'stable/openvpn'
   version: "1.1.0"


### PR DESCRIPTION
Minor touchups to the openvpn helmfile.

Changed the vendor name to `openvpn` as the vanvalenlab really had very little to do with the openvpn chart.

Also, I changed the namespace of the deployment to `kube-system` to reduce clutter in the `deepcell` namespace and because it does not interact with any other pods in `deepcell`, but enables accessing 2 other namespaces from a browser.