### PR TITLE
Update resource requests

### DIFF
--- a/conf/helmfile.d/0200.bucket-monitor.yaml
+++ b/conf/helmfile.d/0200.bucket-monitor.yaml
@@ -36,7 +36,7 @@ releases:
       resources:
         requests:
           cpu: 100m
-          memory: 32Mi
+          memory: 256Mi
         # limits:
         #   cpu: 100m
         #   memory: 64Mi

--- a/conf/helmfile.d/0210.autoscaler.yaml
+++ b/conf/helmfile.d/0210.autoscaler.yaml
@@ -42,8 +42,8 @@ releases:
 
       resources:
         requests:
-          cpu: 100m
-          memory: 32Mi
+          cpu: 650m
+          memory: 64Mi
         # limits:
         #   cpu: 100m
         #   memory: 64Mi

--- a/conf/helmfile.d/0220.redis-janitor.yaml
+++ b/conf/helmfile.d/0220.redis-janitor.yaml
@@ -42,8 +42,8 @@ releases:
 
       resources:
         requests:
-          cpu: 100m
-          memory: 32Mi
+          cpu: 300m
+          memory: 128Mi
         # limits:
         #   cpu: 100m
         #   memory: 64Mi

--- a/conf/helmfile.d/0240.zip-consumer.yaml
+++ b/conf/helmfile.d/0240.zip-consumer.yaml
@@ -35,8 +35,8 @@ releases:
 
       resources:
         requests:
-          cpu: 100m
-          memory: 256Mi
+          cpu: 300m
+          memory: 128Mi
         # limits:
         #   cpu: 100m
         #   memory: 1024Mi

--- a/conf/helmfile.d/0310.tf-serving.yaml
+++ b/conf/helmfile.d/0310.tf-serving.yaml
@@ -36,8 +36,8 @@ releases:
       resources:
         requests:
           nvidia.com/gpu: 1
-          cpu: 200m
-          memory: 3Gi
+          cpu: 500m
+          memory: 3.5Gi
         limits:
           nvidia.com/gpu: 1
           # cpu: 100m

--- a/conf/helmfile.d/0320.tensorboard.yaml
+++ b/conf/helmfile.d/0320.tensorboard.yaml
@@ -55,7 +55,7 @@ releases:
       resources:
         requests:
           cpu: 100m
-          memory: 256Mi
+          memory: 128Mi
 
       env:
         LOG_PREFIX: "tensorboard_logs"

--- a/conf/helmfile.d/0500.elasticsearch.yaml
+++ b/conf/helmfile.d/0500.elasticsearch.yaml
@@ -92,7 +92,7 @@ releases:
             # memory: "1024Mi"
           requests:
             cpu: "25m"
-            memory: "512Mi"
+            memory: "768Mi"
         priorityClassName: ""
         ## (dict) If specified, apply these annotations to each client Pod
         # podAnnotations:
@@ -147,7 +147,7 @@ releases:
             # memory: "1024Mi"
           requests:
             cpu: "25m"
-            memory: "512Mi"
+            memory: "768Mi"
         priorityClassName: ""
         ## (dict) If specified, apply these annotations to each master Pod
         # podAnnotations:
@@ -197,8 +197,8 @@ releases:
             # cpu: "1"
             # memory: "2048Mi"
           requests:
-            cpu: "25m"
-            memory: "1536Mi"
+            cpu: "300m"
+            # memory: "10Gi"
         priorityClassName: ""
         ## (dict) If specified, apply these annotations to each data Pod
         # podAnnotations:

--- a/conf/helmfile.d/0510.kibana.yaml
+++ b/conf/helmfile.d/0510.kibana.yaml
@@ -72,7 +72,9 @@ releases:
       extraContainers: |
       extraVolumeMounts: []
       extraVolumes: []
-      resources: {}
+      resources:
+        requests:
+          memory: 128Mi
       priorityClassName: ""
       tolerations: []
       nodeSelector: {}

--- a/conf/helmfile.d/0520.logstash.yaml
+++ b/conf/helmfile.d/0520.logstash.yaml
@@ -102,8 +102,8 @@ releases:
         #  cpu: 100m
         #  memory: 128Mi
         requests:
-         cpu: 300m
-         memory: 4Gi
+         cpu: 150m
+         memory: 1536Mi
 
       nodeSelector:
         logstash: "yes"


### PR DESCRIPTION
Updated resource requests based on new `grafana` results from a 100K benchmarking run.

This data has also uncovered a memory leak in `kisok-benchmarking` (tracked in vanvalenlab/kiosk-benchmarking#11) but this is not addressed in this PR, just ELK stack (excluding filebeat) and our deepcell stuff (excluding redis-consumers).