### PR TITLE
Override names of consumer helmfiles for clarity

### DIFF
--- a/conf/helmfile.d/0230.image-consumer.yaml
+++ b/conf/helmfile.d/0230.image-consumer.yaml
@@ -8,14 +8,14 @@ helmDefaults:
 releases:
 
 ################################################################################
-## Redis-Consumer ##############################################################
+## Image-Consumer ##############################################################
 ################################################################################
 
 #
 # References:
 #   - [web address of Helm chart's YAML file]
 #
-- name: "redis-consumer"
+- name: "image-consumer"
   namespace: "deepcell"
   labels:
     chart: "redis-consumer"

--- a/conf/helmfile.d/0230.image-consumer.yaml
+++ b/conf/helmfile.d/0230.image-consumer.yaml
@@ -33,6 +33,8 @@ releases:
         tag: "0.1"
         pullPolicy: "Always"
 
+      nameOverride: "image-consumer"
+
       resources:
         requests:
           cpu: 750m

--- a/conf/helmfile.d/0240.zip-consumer.yaml
+++ b/conf/helmfile.d/0240.zip-consumer.yaml
@@ -33,6 +33,8 @@ releases:
         tag: "0.1"
         pullPolicy: "Always"
 
+      nameOverride: "zip-consumer"
+
       resources:
         requests:
           cpu: 300m


### PR DESCRIPTION
Use the `nameOverride` value to define the names of image consumers and zip consumers.  The name redis-consumer should no longer be used as it is too vague.