### PR TITLE
Change tf-serving default model bucket

### DIFF
--- a/conf/helmfile.d/0310.tf-serving.yaml
+++ b/conf/helmfile.d/0310.tf-serving.yaml
@@ -98,5 +98,7 @@ releases:
       secrets:
         AWS_ACCESS_KEY_ID: '{{ env "AWS_ACCESS_KEY_ID" | default "NA" }}'
         AWS_SECRET_ACCESS_KEY: '{{ env "AWS_SECRET_ACCESS_KEY" | default "NA" }}'
-        AWS_S3_BUCKET: '{{ env "AWS_S3_BUCKET" | default "NA" }}'
-        GCLOUD_STORAGE_BUCKET: '{{ env "GKE_BUCKET" | default "NA" }}'
+        # AWS_S3_BUCKET: '{{ env "AWS_S3_BUCKET" | default "NA" }}'
+        # GCLOUD_STORAGE_BUCKET: '{{ env "GKE_BUCKET" | default "NA" }}'
+        AWS_S3_BUCKET: "deepcell-models"
+        GCLOUD_STORAGE_BUCKET: "deepcell-models"

--- a/conf/helmfile.d/0310.tf-serving.yaml
+++ b/conf/helmfile.d/0310.tf-serving.yaml
@@ -98,7 +98,6 @@ releases:
       secrets:
         AWS_ACCESS_KEY_ID: '{{ env "AWS_ACCESS_KEY_ID" | default "NA" }}'
         AWS_SECRET_ACCESS_KEY: '{{ env "AWS_SECRET_ACCESS_KEY" | default "NA" }}'
-        # AWS_S3_BUCKET: '{{ env "AWS_S3_BUCKET" | default "NA" }}'
+        AWS_S3_BUCKET: '{{ env "AWS_S3_BUCKET" | default "NA" }}'
         # GCLOUD_STORAGE_BUCKET: '{{ env "GKE_BUCKET" | default "NA" }}'
-        AWS_S3_BUCKET: "deepcell-models"
         GCLOUD_STORAGE_BUCKET: "deepcell-models"


### PR DESCRIPTION
Use `deepcell-models` as the default model bucket. This will allow new deployments to deploy default models instead of an empty bucket.

Fixes #181 
Fixes #175 