### PR TITLE
Generalize chart node selectors and tolerations.

### DIFF
--- a/conf/ELK_helmfiles/0530.filebeat.yaml
+++ b/conf/ELK_helmfiles/0530.filebeat.yaml
@@ -82,21 +82,5 @@ releases:
         http.enabled: false
         http.port: 5066
       tolerations:
-        - key: node-role.kubernetes.io/master
-          operator: Exists
-          effect: NoSchedule
-        - key: nvidia.com/gpu
-          operator: Exists
-          effect: NoSchedule
-        - key: elasticsearch_data
-          operator: Exists
-          effect: NoSchedule
-        - key: prediction_gpu
-          operator: Exists
-          effect: NoSchedule
-        - key: training_gpu
-          operator: Exists
-          effect: NoSchedule
-        - key: logstash
-          operator: Exists
+        - operator: Exists
           effect: NoSchedule

--- a/conf/ELK_helmfiles/0530.filebeat.yaml
+++ b/conf/ELK_helmfiles/0530.filebeat.yaml
@@ -97,9 +97,6 @@ releases:
         - key: training_gpu
           operator: Exists
           effect: NoSchedule
-        - key: rc_dp
-          operator: Exists
-          effect: NoSchedule
         - key: logstash
           operator: Exists
           effect: NoSchedule

--- a/conf/charts/data-processing/templates/deployment.yaml
+++ b/conf/charts/data-processing/templates/deployment.yaml
@@ -44,6 +44,10 @@ spec:
           value: {{ $value | quote }}
 {{- end }}
 {{- end }}
+    {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+    {{- end }}
 {{ $secrets_name := .Values.secrets_name }}
 {{- range $name, $value := .Values.secrets }}
 {{- if not ( empty $value) }}

--- a/conf/charts/data-processing/templates/deployment.yaml
+++ b/conf/charts/data-processing/templates/deployment.yaml
@@ -21,6 +21,18 @@ spec:
       annotations:
 {{ toYaml .Values.annotations | indent 8 }}
     spec:
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -44,18 +56,6 @@ spec:
           value: {{ $value | quote }}
 {{- end }}
 {{- end }}
-    {{- with .Values.nodeSelector }}
-      nodeSelector:
-{{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- with .Values.affinity }}
-      affinity:
-{{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- with .Values.tolerations }}
-      tolerations:
-{{ toYaml . | indent 8 }}
-    {{- end }}
 {{ $secrets_name := .Values.secrets_name }}
 {{- range $name, $value := .Values.secrets }}
 {{- if not ( empty $value) }}

--- a/conf/charts/data-processing/templates/deployment.yaml
+++ b/conf/charts/data-processing/templates/deployment.yaml
@@ -44,9 +44,17 @@ spec:
           value: {{ $value | quote }}
 {{- end }}
 {{- end }}
-    {{- if .Values.nodeSelector }}
+    {{- with .Values.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.nodeSelector | indent 8 }}
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
     {{- end }}
 {{ $secrets_name := .Values.secrets_name }}
 {{- range $name, $value := .Values.secrets }}

--- a/conf/charts/data-processing/templates/deployment.yaml
+++ b/conf/charts/data-processing/templates/deployment.yaml
@@ -21,13 +21,6 @@ spec:
       annotations:
 {{ toYaml .Values.annotations | indent 8 }}
     spec:
-      # TODO: generalize the node selectors
-      nodeSelector:
-        rc_dp: "yes"
-      tolerations:
-      - key: rc_dp
-        operator: Exists
-        effect: NoSchedule
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/conf/charts/data-processing/values.yaml
+++ b/conf/charts/data-processing/values.yaml
@@ -11,6 +11,12 @@ image:
 
 resources: {}
 
+tolerations: {}
+
+affinity: {}
+
+nodeSelector: {}
+
 service:
   type: "ClusterIP"
 

--- a/conf/charts/redis-consumer/templates/deployment.yaml
+++ b/conf/charts/redis-consumer/templates/deployment.yaml
@@ -19,12 +19,6 @@ spec:
         app: {{ template "name" . }}
         release: {{ .Release.Name }}
     spec:
-      nodeSelector:
-        rc_dp: "yes"
-      tolerations:
-      - key: rc_dp
-        operator: Exists
-        effect: NoSchedule
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/conf/charts/redis-consumer/templates/deployment.yaml
+++ b/conf/charts/redis-consumer/templates/deployment.yaml
@@ -19,6 +19,18 @@ spec:
         app: {{ template "name" . }}
         release: {{ .Release.Name }}
     spec:
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -34,18 +46,6 @@ spec:
           value: {{ $value | quote }}
 {{- end }}
 {{- end }}
-    {{- with .Values.nodeSelector }}
-      nodeSelector:
-{{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- with .Values.affinity }}
-      affinity:
-{{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- with .Values.tolerations }}
-      tolerations:
-{{ toYaml . | indent 8 }}
-    {{- end }}
 {{ $dot := . }}
 {{- range $name, $value := .Values.secrets }}
 {{- if not ( empty $value) }}

--- a/conf/charts/redis-consumer/templates/deployment.yaml
+++ b/conf/charts/redis-consumer/templates/deployment.yaml
@@ -34,9 +34,17 @@ spec:
           value: {{ $value | quote }}
 {{- end }}
 {{- end }}
-    {{- if .Values.nodeSelector }}
+    {{- with .Values.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.nodeSelector | indent 8 }}
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
     {{- end }}
 {{ $dot := . }}
 {{- range $name, $value := .Values.secrets }}

--- a/conf/charts/redis-consumer/templates/deployment.yaml
+++ b/conf/charts/redis-consumer/templates/deployment.yaml
@@ -34,6 +34,10 @@ spec:
           value: {{ $value | quote }}
 {{- end }}
 {{- end }}
+    {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+    {{- end }}
 {{ $dot := . }}
 {{- range $name, $value := .Values.secrets }}
 {{- if not ( empty $value) }}

--- a/conf/charts/redis-consumer/values.yaml
+++ b/conf/charts/redis-consumer/values.yaml
@@ -11,6 +11,12 @@ image:
 
 resources: {}
 
+tolerations: {}
+
+affinity: {}
+
+nodeSelector: {}
+
 service:
   type: "ClusterIP"
 

--- a/conf/charts/tf-serving/templates/deployment.yaml
+++ b/conf/charts/tf-serving/templates/deployment.yaml
@@ -22,19 +22,14 @@ spec:
         release: {{ .Release.Name }}
     spec:
       restartPolicy: "Always"
+    {{- with .Values.nodeSelector }}
       nodeSelector:
-{{- range $name, $value := .Values.nodeSelector }}
-{{- if not ( empty $value) }}
-        {{ $name }}: {{ $value | quote }}
-{{- end }}
-{{- end }}
+    {{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
       tolerations:
-      - key: "nvidia.com/gpu"
-        operator: "Exists"
-        effect: "NoSchedule"
-      - key: "prediction_gpu"
-        operator: "Exists"
-        effect: "NoSchedule"
+{{ toYaml . | indent 8 }}
+    {{- end }}
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/conf/charts/tf-serving/templates/deployment.yaml
+++ b/conf/charts/tf-serving/templates/deployment.yaml
@@ -24,7 +24,11 @@ spec:
       restartPolicy: "Always"
     {{- with .Values.nodeSelector }}
       nodeSelector:
-    {{ toYaml . | indent 8 }}
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
     {{- end }}
     {{- with .Values.tolerations }}
       tolerations:

--- a/conf/charts/tf-serving/values.yaml
+++ b/conf/charts/tf-serving/values.yaml
@@ -35,6 +35,16 @@ resources: {}
   # limits:
   #   nvidia.com/gpu: 1
 
+tolerations: {}
+# - key: "nvidia.com/gpu"
+#   operator: "Exists"
+#   effect: "NoSchedule"
+# - key: "prediction_gpu"
+#   operator: "Exists"
+#   effect: "NoSchedule"
+
+affinity: {}
+
 env:
   PORT: 8500
   REST_API_PORT: 8501

--- a/conf/helmfile.d/0230.redis-consumer.yaml
+++ b/conf/helmfile.d/0230.redis-consumer.yaml
@@ -41,6 +41,14 @@ releases:
         #   cpu: 100m
         #   memory: 2Gi
 
+      tolerations:
+        - key: consumer
+          operator: Exists
+          effect: NoSchedule
+
+      nodeSelector:
+        - consumer: "yes"
+
       env:
         DEBUG: "true"
         INTERVAL: 1

--- a/conf/helmfile.d/0230.redis-consumer.yaml
+++ b/conf/helmfile.d/0230.redis-consumer.yaml
@@ -47,7 +47,7 @@ releases:
           effect: NoSchedule
 
       nodeSelector:
-        - consumer: "yes"
+        consumer: "yes"
 
       env:
         DEBUG: "true"

--- a/conf/helmfile.d/0240.zip-consumer.yaml
+++ b/conf/helmfile.d/0240.zip-consumer.yaml
@@ -33,6 +33,8 @@ releases:
         tag: "0.4.1"
         pullPolicy: "Always"
 
+      nameOverride: zip-consumer
+
       resources:
         requests:
           cpu: 200m
@@ -41,7 +43,13 @@ releases:
         #   cpu: 100m
         #   memory: 1024Mi
 
-      nameOverride: zip-consumer
+      tolerations:
+        - key: consumer
+          operator: Exists
+          effect: NoSchedule
+
+      nodeSelector:
+        - consumer: "yes"
 
       env:
         REDIS_HOST: "redis"

--- a/conf/helmfile.d/0240.zip-consumer.yaml
+++ b/conf/helmfile.d/0240.zip-consumer.yaml
@@ -49,7 +49,7 @@ releases:
           effect: NoSchedule
 
       nodeSelector:
-        - consumer: "yes"
+        consumer: "yes"
 
       env:
         REDIS_HOST: "redis"

--- a/conf/helmfile.d/0250.tracking-consumer.yaml
+++ b/conf/helmfile.d/0250.tracking-consumer.yaml
@@ -43,6 +43,14 @@ releases:
         #   cpu: 100m
         #   memory: 1024Mi
 
+      tolerations:
+        - key: consumer
+          operator: Exists
+          effect: NoSchedule
+
+      nodeSelector:
+        - consumer: "yes"
+
       env:
         DEBUG: "true"
         INTERVAL: 1

--- a/conf/helmfile.d/0250.tracking-consumer.yaml
+++ b/conf/helmfile.d/0250.tracking-consumer.yaml
@@ -49,7 +49,7 @@ releases:
           effect: NoSchedule
 
       nodeSelector:
-        - consumer: "yes"
+        consumer: "yes"
 
       env:
         DEBUG: "true"

--- a/conf/helmfile.d/0310.tf-serving.yaml
+++ b/conf/helmfile.d/0310.tf-serving.yaml
@@ -35,7 +35,6 @@ releases:
 
       resources:
         requests:
-          nvidia.com/gpu: 1
           cpu: 1
           memory: 3.5Gi
         limits:

--- a/conf/helmfile.d/0310.tf-serving.yaml
+++ b/conf/helmfile.d/0310.tf-serving.yaml
@@ -78,10 +78,12 @@ releases:
 
       tolerations:
       - key: "nvidia.com/gpu"
-        operator: "Exists"
+        operator: "Equal"
+        value: "present"
         effect: "NoSchedule"
       - key: "prediction_gpu"
-        operator: "Exists"
+        operator: "Equal"
+        value: "yes"
         effect: "NoSchedule"
 
       env:

--- a/conf/helmfile.d/0310.tf-serving.yaml
+++ b/conf/helmfile.d/0310.tf-serving.yaml
@@ -43,6 +43,16 @@ releases:
           # cpu: 2
           # memory: 8Gi
 
+      tolerations:
+      - key: "nvidia.com/gpu"
+        operator: "Equal"
+        value: "present"
+        effect: "NoSchedule"
+      - key: "prediction_gpu"
+        operator: "Equal"
+        value: "yes"
+        effect: "NoSchedule"
+
       service:
         type: "ClusterIP"
 
@@ -75,16 +85,6 @@ releases:
         cloud.google.com/gke-accelerator: '{{ env "PREDICTION_GPU_TYPE" | default "nvidia-tesla-k80" }}'
         cloud.google.com/gke-preemptible: "true"
 {{ end }}
-
-      tolerations:
-      - key: "nvidia.com/gpu"
-        operator: "Equal"
-        value: "present"
-        effect: "NoSchedule"
-      - key: "prediction_gpu"
-        operator: "Equal"
-        value: "yes"
-        effect: "NoSchedule"
 
       env:
         PORT: 8500

--- a/conf/helmfile.d/0310.tf-serving.yaml
+++ b/conf/helmfile.d/0310.tf-serving.yaml
@@ -35,6 +35,7 @@ releases:
 
       resources:
         requests:
+          nvidia.com/gpu: 1
           cpu: 1
           memory: 3.5Gi
         limits:
@@ -44,12 +45,10 @@ releases:
 
       tolerations:
       - key: "nvidia.com/gpu"
-        operator: "Equal"
-        value: "present"
+        operator: "Exists"
         effect: "NoSchedule"
       - key: "prediction_gpu"
-        operator: "Equal"
-        value: "yes"
+        operator: "Exists"
         effect: "NoSchedule"
 
       service:

--- a/conf/helmfile.d/0310.tf-serving.yaml
+++ b/conf/helmfile.d/0310.tf-serving.yaml
@@ -76,6 +76,14 @@ releases:
         cloud.google.com/gke-preemptible: "true"
 {{ end }}
 
+      tolerations:
+      - key: "nvidia.com/gpu"
+        operator: "Exists"
+        effect: "NoSchedule"
+      - key: "prediction_gpu"
+        operator: "Exists"
+        effect: "NoSchedule"
+
       env:
         PORT: 8500
         REST_API_PORT: 8501

--- a/conf/helmfile.d/0399.data-processing.yaml
+++ b/conf/helmfile.d/0399.data-processing.yaml
@@ -73,7 +73,7 @@ releases:
           effect: NoSchedule
 
       nodeSelector:
-        - consumer: "yes"
+        consumer: "yes"
 
       env:
         LISTEN_PORT: 8080

--- a/conf/helmfile.d/0399.data-processing.yaml
+++ b/conf/helmfile.d/0399.data-processing.yaml
@@ -67,6 +67,14 @@ releases:
           cpu: 2
           memory: 3Gi
 
+      tolerations:
+        - key: consumer
+          operator: Exists
+          effect: NoSchedule
+
+      nodeSelector:
+        - consumer: "yes"
+
       env:
         LISTEN_PORT: 8080
         PROMETHEUS_PORT: 8000

--- a/conf/helmfile.d/0610.prometheus-adapter.yaml
+++ b/conf/helmfile.d/0610.prometheus-adapter.yaml
@@ -27,7 +27,7 @@ releases:
     vendor: "coreos"
     default: "true"
   chart: "stable/prometheus-adapter"
-  version: "v0.5.0"
+  version: "1.4.0"
   wait: true
   values:
     - affinity: {}

--- a/conf/helmfile.d/0610.prometheus-adapter.yaml
+++ b/conf/helmfile.d/0610.prometheus-adapter.yaml
@@ -27,7 +27,7 @@ releases:
     vendor: "coreos"
     default: "true"
   chart: "stable/prometheus-adapter"
-  version: "1.4.0"
+  version: "v0.5.0"
   wait: true
   values:
     - affinity: {}

--- a/conf/patches/gke-node-pool-destruction.sh
+++ b/conf/patches/gke-node-pool-destruction.sh
@@ -31,3 +31,11 @@ if [ "${ELK_DEPLOYMENT_TOGGLE}" == "ON" ] || [ "${ELK_DEPLOYMENT_TOGGLE}" == "on
     done
     echo "Logstash CPU node pool destruction finished."
 fi
+
+echo "Destroying consumer CPU node pool..."
+until gcloud container node-pools delete consumer-cpu --quiet --region ${GKE_COMPUTE_REGION}
+do
+    echo "Consumer CPU node pool destruction failed. Trying again in 30 seconds."
+    sleep 30
+done
+echo "Consumer CPU node pool destruction finished."

--- a/conf/patches/gke-node-pool-destruction.sh
+++ b/conf/patches/gke-node-pool-destruction.sh
@@ -31,11 +31,3 @@ if [ "${ELK_DEPLOYMENT_TOGGLE}" == "ON" ] || [ "${ELK_DEPLOYMENT_TOGGLE}" == "on
     done
     echo "Logstash CPU node pool destruction finished."
 fi
-
-echo "Destroying redis-consumer, data-processing CPU node pool..."
-until gcloud container node-pools delete rc-dp-cpu --quiet --region ${GKE_COMPUTE_REGION}
-do
-    echo "Redis-consumer, data-processing CPU node pool destruction failed. Trying again in 30 seconds."
-    sleep 30
-done
-echo "Redis-consumer, data-processing CPU node pool destruction finished."

--- a/conf/tasks/Makefile.gke
+++ b/conf/tasks/Makefile.gke
@@ -17,9 +17,6 @@ export NODE_MIN_SIZE ?= 1
 export NODE_MAX_SIZE ?= 10
 export GKE_NODE_SERVICE_ACCOUNT_EMAIL ?= $(CLOUDSDK_CONTAINER_CLUSTER)@$(CLOUDSDK_CORE_PROJECT).iam.gserviceaccount.com
 
-# Non-GPU machine type
-export RC_DP_MACHINE_TYPE ?= n1-standard-8
-
 # Not all GPU types are available in all regions/availability zones
 export GPU_COMPUTE_REGION ?= $(GKE_COMPUTE_REGION)
 export PREDICTION_GPU_TYPE ?= nvidia-tesla-t4
@@ -105,23 +102,6 @@ gke/list/billing-accounts:
 #		--enable-autoupgrade
 gke/create/node-pools:
 	@gcloud components install beta --quiet
-	@echo "Creating redis-consumer and data-processing CPU node pool..."
-	@echo "Using the following command: "
-	gcloud container node-pools create rc-dp-cpu \
-		--cluster $(CLUSTER_NAME) \
-		--service-account=$(GKE_NODE_SERVICE_ACCOUNT_EMAIL) \
-		--region $(GKE_COMPUTE_REGION) \
-		--num-nodes 1 \
-		--min-nodes 1 \
-		--max-nodes ${NODE_MAX_SIZE} \
-		--machine-type=${RC_DP_MACHINE_TYPE} \
-		--enable-autoscaling \
-		--enable-autorepair \
-		--no-enable-autoupgrade \
-		--preemptible \
-		--node-labels rc_dp=yes \
-		--node-taints rc_dp=yes:NoSchedule \
-		|| echo "Elasticsearch CPU node pool creation failed."
 	@echo "Creating prediction GPU node pool..."
 	@echo "Using the following command: "
 	gcloud beta container node-pools create prediction-gpu \
@@ -261,7 +241,7 @@ gke/destroy/helm:
 	-helm reset --force --tiller-connection-timeout=2
 	-kubectl delete clusterrolebinding tiller-cluster-rule
 	-kubectl delete serviceaccount --namespace kube-system tiller
-	
+
 ## Deploy GKE Nvidia drivers
 gke/deploy/nvidia:
 	@echo "Deploying NVIDIA drivers for GPU instances..."
@@ -279,13 +259,13 @@ gke/create/all: \
 	gke/create/bucket \
 	gke/deploy/helm \
 	gke/deploy/nvidia
-	@echo "GKE cluster created" 
+	@echo "GKE cluster created"
 	@exit 0
 
 ## Destroy Cluster
 gke/destroy/all: \
 	gke/destroy/node-pools \
 	gke/destroy/cluster \
-	gke/destroy/service-account 
-	@echo "GKE cluster destroyed" 
+	gke/destroy/service-account
+	@echo "GKE cluster destroyed"
 	@exit 0

--- a/conf/tasks/Makefile.gke
+++ b/conf/tasks/Makefile.gke
@@ -101,10 +101,9 @@ gke/list/billing-accounts:
 ## Create GKE GPU node pool
 #		--enable-autoupgrade
 gke/create/node-pools:
-	@gcloud components install beta --quiet
 	@echo "Creating prediction GPU node pool..."
 	@echo "Using the following command: "
-	gcloud beta container node-pools create prediction-gpu \
+	gcloud container node-pools create prediction-gpu \
 		--cluster $(CLUSTER_NAME) \
 		--accelerator type=$(PREDICTION_GPU_TYPE),count=$(GPU_PER_NODE) \
 		--service-account=$(GKE_NODE_SERVICE_ACCOUNT_EMAIL) \
@@ -121,7 +120,7 @@ gke/create/node-pools:
 		|| echo "Prediction GPU node pool creation failed."
 	@echo "Creating training GPU node pool..."
 	@echo "Using the following command: "
-	gcloud beta container node-pools create training-gpu \
+	gcloud container node-pools create training-gpu \
 		--cluster $(CLUSTER_NAME) \
 		--accelerator type=$(TRAINING_GPU_TYPE),count=$(GPU_PER_NODE) \
 		--service-account=$(GKE_NODE_SERVICE_ACCOUNT_EMAIL) \
@@ -181,7 +180,8 @@ gke/deploy/elk:
 	fi
 
 # https://cloud.google.com/kubernetes-engine/docs/how-to/gpus#gpu_pool
-# When you add a GPU node pool to an existing cluster that already runs a non-GPU node pool, GKE automatically taints the GPU nodes with the following node taint
+# When you add a GPU node pool to an existing cluster that already runs a non-GPU
+# node pool, GKE automatically taints the GPU nodes with the following node taint
 #		--node-taints "nvidia.com/gpu=:NoSchedule"
 
 ## Destroy GKE GPU node pool

--- a/conf/tasks/Makefile.gke
+++ b/conf/tasks/Makefile.gke
@@ -18,7 +18,7 @@ export NODE_MAX_SIZE ?= 10
 export GKE_NODE_SERVICE_ACCOUNT_EMAIL ?= $(CLOUDSDK_CONTAINER_CLUSTER)@$(CLOUDSDK_CORE_PROJECT).iam.gserviceaccount.com
 
 # Non-GPU machine type
-export CONSUMER_MACHINE_TYPE ?= n1-highmem-2
+export CONSUMER_MACHINE_TYPE ?= n1-standard-8
 
 # Not all GPU types are available in all regions/availability zones
 export GPU_COMPUTE_REGION ?= $(GKE_COMPUTE_REGION)

--- a/conf/tasks/Makefile.gke
+++ b/conf/tasks/Makefile.gke
@@ -17,6 +17,9 @@ export NODE_MIN_SIZE ?= 1
 export NODE_MAX_SIZE ?= 10
 export GKE_NODE_SERVICE_ACCOUNT_EMAIL ?= $(CLOUDSDK_CONTAINER_CLUSTER)@$(CLOUDSDK_CORE_PROJECT).iam.gserviceaccount.com
 
+# Non-GPU machine type
+export CONSUMER_MACHINE_TYPE ?= n1-highmem-2
+
 # Not all GPU types are available in all regions/availability zones
 export GPU_COMPUTE_REGION ?= $(GKE_COMPUTE_REGION)
 export PREDICTION_GPU_TYPE ?= nvidia-tesla-t4
@@ -101,6 +104,23 @@ gke/list/billing-accounts:
 ## Create GKE GPU node pool
 #		--enable-autoupgrade
 gke/create/node-pools:
+	@echo "Creating consumer CPU node pool..."
+	@echo "Using the following command: "
+	gcloud container node-pools create consumer-cpu \
+		--cluster $(CLUSTER_NAME) \
+		--service-account=$(GKE_NODE_SERVICE_ACCOUNT_EMAIL) \
+		--region $(GKE_COMPUTE_REGION) \
+		--num-nodes 1 \
+		--min-nodes 1 \
+		--max-nodes ${NODE_MAX_SIZE} \
+		--machine-type=${CONSUMER_MACHINE_TYPE} \
+		--enable-autoscaling \
+		--enable-autorepair \
+		--no-enable-autoupgrade \
+		--preemptible \
+		--node-labels consumer=yes \
+		--node-taints consumer=yes:NoSchedule \
+		|| echo "Elasticsearch CPU node pool creation failed."
 	@echo "Creating prediction GPU node pool..."
 	@echo "Using the following command: "
 	gcloud container node-pools create prediction-gpu \


### PR DESCRIPTION
The `rc_dp` node pool drives up the minimum CPU count for our cluster, making it difficult to run with new accounts. Additionally, the workload of the default consumers has been optimized and the data-processing API has been deprecated, the utility of a distinct node pool is diminished.

Further, the `tf-serving`, `data-processing`, and `redis-consumer` charts have been udpated with generalized values for annotations, tolerations, nodeSelectors, and affinities.  This way, the toleration for a future node pool is easy to re-implement.

Fixes #178 

---

UPDATE: Consumers will run out of memory if put on too small of a node!  This can be mitigated by keeping the node pool. However, the node pool has been renamed, and the other chart tolerations are generalized for helmfile overrides.