### PR TITLE
Update default menu options for minimum cluster.

### DIFF
--- a/conf/tasks/Makefile.gke
+++ b/conf/tasks/Makefile.gke
@@ -261,7 +261,7 @@ gke/destroy/helm:
 	-helm reset --force --tiller-connection-timeout=2
 	-kubectl delete clusterrolebinding tiller-cluster-rule
 	-kubectl delete serviceaccount --namespace kube-system tiller
-	
+
 ## Deploy GKE Nvidia drivers
 gke/deploy/nvidia:
 	@echo "Deploying NVIDIA drivers for GPU instances..."
@@ -279,13 +279,13 @@ gke/create/all: \
 	gke/create/bucket \
 	gke/deploy/helm \
 	gke/deploy/nvidia
-	@echo "GKE cluster created" 
+	@echo "GKE cluster created"
 	@exit 0
 
 ## Destroy Cluster
 gke/destroy/all: \
 	gke/destroy/node-pools \
 	gke/destroy/cluster \
-	gke/destroy/service-account 
-	@echo "GKE cluster destroyed" 
+	gke/destroy/service-account
+	@echo "GKE cluster destroyed"
 	@exit 0

--- a/conf/tasks/Makefile.gke
+++ b/conf/tasks/Makefile.gke
@@ -12,13 +12,13 @@ export CLOUDSDK_CONFIG=/localhost/.config/gcloud/
 
 export CLUSTER_NAME ?= deepcell
 export GKE_COMPUTE_REGION ?= us-west1
-export GKE_MACHINE_TYPE ?= n1-standard-2
+export GKE_MACHINE_TYPE ?= n1-standard-1
 export NODE_MIN_SIZE ?= 1
 export NODE_MAX_SIZE ?= 10
 export GKE_NODE_SERVICE_ACCOUNT_EMAIL ?= $(CLOUDSDK_CONTAINER_CLUSTER)@$(CLOUDSDK_CORE_PROJECT).iam.gserviceaccount.com
 
 # Non-GPU machine type
-export RC_DP_MACHINE_TYPE ?= n1-standard-8
+export RC_DP_MACHINE_TYPE ?= n1-highmem-2
 
 # Not all GPU types are available in all regions/availability zones
 export GPU_COMPUTE_REGION ?= $(GKE_COMPUTE_REGION)

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -263,7 +263,7 @@ function configure_gke() {
 	  return 0
   fi
 
-  export GKE_MACHINE_TYPE=$(inputbox "Google Cloud" "Node (non-GPU) Type" "${GKE_MACHINE_TYPE:-n1-standard-4}")
+  export GKE_MACHINE_TYPE=$(inputbox "Google Cloud" "Node (non-GPU) Type" "${GKE_MACHINE_TYPE:-n1-standard-1}")
   if [ "$GKE_MACHINE_TYPE" = "" ]; then
 	  return 0
   fi

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -277,7 +277,7 @@ function configure_gke() {
   fi
 
   local gpus_in_region=$(gcloud compute accelerator-types list | grep ${GKE_COMPUTE_REGION} | awk '{print $1}' | sort -u | awk '{print $1 " _ OFF"}')
-  local gpus_with_default=${gpus_in_region/nvidia-tesla-v100 _ OFF/nvidia-tesla-v100 _ ON}
+  local gpus_with_default=${gpus_in_region/nvidia-tesla-t4 _ OFF/nvidia-tesla-t4 _ ON}
   local base_box_height=7
   local selector_box_lines=$(($(echo "${gpus_in_region}" | tr -cd '\n' | wc -c) + 1))
   local total_lines=$(($base_box_height + $selector_box_lines))
@@ -285,6 +285,7 @@ function configure_gke() {
       "Choose a GPU for prediction (not training) from the GPU types available in your region: \nPress the spacebar to select and Enter to continue." \
 	  $total_lines 60 $selector_box_lines "$gpus_with_default")
 
+  local gpus_with_default=${gpus_in_region/nvidia-tesla-v100 _ OFF/nvidia-tesla-v100 _ ON}
   export TRAINING_GPU_TYPE=$(radiobox "Google Cloud" \
       "Choose a GPU for training (not prediction) from the GPU types available in your region: \nPress the spacebar to select and Enter to continue." \
 	  $total_lines 60 $selector_box_lines "$gpus_with_default")


### PR DESCRIPTION
Changed GKE_MACHINE_TYPE default to `n1-standard-1`, changed the rcdp node pool nodes to `n1-highmem-2` and changed the default menu option for the prediction GPU to `nvidia-tesla-t4`.

These changes will help the most minimum account get up and running with a basic cluster.