### PR TITLE
Amend cluster destroy to include persistent disks

### DIFF
--- a/conf/patches/gke-pd-destruction.sh
+++ b/conf/patches/gke-pd-destruction.sh
@@ -1,5 +1,8 @@
 echo "Destroying orphaned persistent disks..."
 while IFS= read -r result
 do
-    gcloud compute disks delete $result --quiet --zone=${GPU_COMPUTE_REGION}
-done < <(gcloud compute disks list | grep ${cluster_name} | awk '{print $1}')
+    VAR_NAME=$(echo $result | awk '{print $1}')
+    VAR_REGION=$(echo $result | awk '{print $2}')
+    gcloud compute disks delete $VAR_NAME --quiet --zone=$VAR_REGION
+done < <(gcloud compute disks list | grep $CLUSTER_NAME)
+

--- a/conf/patches/gke-pd-destruction.sh
+++ b/conf/patches/gke-pd-destruction.sh
@@ -1,0 +1,5 @@
+echo "Destroying orphaned persistent disks..."
+while IFS= read -r result
+do
+    gcloud compute disks delete $result --quiet --zone=${GPU_COMPUTE_REGION}
+done < <(gcloud compute disks list | grep ${cluster_name} | awk '{print $1}')

--- a/conf/tasks/Makefile.gke
+++ b/conf/tasks/Makefile.gke
@@ -213,6 +213,14 @@ gke/destroy/node-pools:
 	@echo " "
 	@echo " "
 
+## Destroy Orphaned GKE persistent disks
+gke/destroy/pds:
+	@echo "Destroying orphaned persistent disks."
+	/conf/patches/gke-pd-destruction.sh
+	@echo "Orphaned persistent disks destroyed."
+	@echo " "
+	@echo " "
+
 # https://cloud.google.com/storage/docs/access-control/iam-roles
 ## Create Service Account used by deepcell
 gke/create/service-account:
@@ -286,6 +294,7 @@ gke/create/all: \
 gke/destroy/all: \
 	gke/destroy/node-pools \
 	gke/destroy/cluster \
-	gke/destroy/service-account
+	gke/destroy/service-account \
+	gke/destroy/pds
 	@echo "GKE cluster destroyed"
 	@exit 0


### PR DESCRIPTION
Currently, the Destroy Cluster command leaves behind several orphaned persistent disks. This PR resolves this issue by calling for their deletion as part of the destroy script.