### PR TITLE
Bump redis-consumer helmfiles to 0.4.3

### DIFF
--- a/conf/helmfile.d/0230.redis-consumer.yaml
+++ b/conf/helmfile.d/0230.redis-consumer.yaml
@@ -30,7 +30,7 @@ releases:
 
       image:
         repository: "vanvalenlab/kiosk-redis-consumer"
-        tag: "0.4.1"
+        tag: "0.4.3"
         pullPolicy: "Always"
 
       resources:

--- a/conf/helmfile.d/0240.zip-consumer.yaml
+++ b/conf/helmfile.d/0240.zip-consumer.yaml
@@ -30,7 +30,7 @@ releases:
 
       image:
         repository: "vanvalenlab/kiosk-redis-consumer"
-        tag: "0.4.1"
+        tag: "0.4.3"
         pullPolicy: "Always"
 
       nameOverride: zip-consumer

--- a/conf/helmfile.d/0250.tracking-consumer.yaml
+++ b/conf/helmfile.d/0250.tracking-consumer.yaml
@@ -30,7 +30,7 @@ releases:
 
       image:
         repository: "vanvalenlab/kiosk-redis-consumer"
-        tag: "0.4.1"
+        tag: "0.4.3"
         pullPolicy: "Always"
 
       nameOverride: "tracking-consumer"


### PR DESCRIPTION
`kiosk-redis-consumer 0.4.3` allows for faster tracking and caps the number of retries on prediction jobs, preventing jobs from never finishing.