### PR TITLE
Fix the order of the options for the dialog function

### DIFF
--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -54,10 +54,9 @@ function radiobox() {
   IFS=$'\n' read -r -a gpu_array <<< "$text_fields"
   shift
   value=$(dialog --title "$title" \
-            --radiolist "$label" "$h" "$w" "$menu_h" \
-	    	$text_fields \
             --backtitle "${BRAND}" \
-            --output-fd 1)
+            --output-fd 1 \
+            --radiolist "$label" "$h" "$w" "$menu_h" $text_fields)
   echo $value
 }
 

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -37,9 +37,9 @@ function inputbox() {
   local h=${5:-8}
   shift
   value=$(dialog --title "$title" \
-            --inputbox "$label" "$h" "$w" "$default" \
             --backtitle "${BRAND}" \
-            --output-fd 1)
+            --output-fd 1 \
+            --inputbox "$label" "$h" "$w" "$default")
   echo $value
 }
 


### PR DESCRIPTION
The order of the options for the dialog function within inputbox was incorrect. This triggered an input error message but did not affect performance.

---

Fixes #183 