### PR TITLE
Check if $CACHE_PATH is empty before attempting to create it

### DIFF
--- a/conf/Makefile
+++ b/conf/Makefile
@@ -20,7 +20,7 @@ destroy: \
 
 ## Create $CACHE_PATH directory, if it doesn't already exist
 create_cache_path:
-	@if [ ! -d "$(CACHE_PATH)" ]; \
+	@if [! -z "$(CACHE_PATH)"] && [ ! -d "$(CACHE_PATH)" ]; \
 	then \
-	    mkdir $(CACHE_PATH); \
+	  mkdir $(CACHE_PATH); \
 	fi

--- a/conf/Makefile
+++ b/conf/Makefile
@@ -20,7 +20,7 @@ destroy: \
 
 ## Create $CACHE_PATH directory, if it doesn't already exist
 create_cache_path:
-	@if [! -z "$(CACHE_PATH)"] && [ ! -d "$(CACHE_PATH)" ]; \
+	@if [ ! -z "$(CACHE_PATH)" ] && [ ! -d "$(CACHE_PATH)" ]; \
 	then \
 	  mkdir $(CACHE_PATH); \
 	fi


### PR DESCRIPTION
Resolves an issue where an unset `$CACHE_PATH` was causing the below error:

<img width="570" alt="Screen Shot 2020-01-16 at 12 45 44 PM" src="https://user-images.githubusercontent.com/7930703/72563982-a5a20d00-3863-11ea-8cc3-0e9574d50c16.png">
