### PR TITLE
Do not include build-harness Makefiles in conf/Makefile.

### DIFF
--- a/conf/Makefile
+++ b/conf/Makefile
@@ -1,6 +1,6 @@
 export CLOUD_PROVIDER ?= aws
 
-include /build-harness/templates/Makefile.build-harness
+# include /build-harness/templates/Makefile.build-harness
 
 include tasks/Makefile.*
 


### PR DESCRIPTION
Fixes #210 

It seems that the build-harness Makefile causes some make target errors which get logged every time a make command is entered.