### PR TITLE
add make command to destroy prometheus-operator and CRDs.

### DIFF
--- a/conf/tasks/Makefile.kubectl
+++ b/conf/tasks/Makefile.kubectl
@@ -33,6 +33,15 @@ kubectl/display/ip:
 	@echo " "
 	@echo export CLUSTER_ADDRESS=${IP_VAR} > ./cluster_address
 
+## Tear down prometheus-operator and it's CRDs
+kubectl/destroy/prometheus/operator:
+	@helm delete prometheus-operator --purge
+	@kubectl delete crd prometheuses.monitoring.coreos.com
+	@kubectl delete crd prometheusrules.monitoring.coreos.com
+	@kubectl delete crd servicemonitors.monitoring.coreos.com
+	@kubectl delete crd alertmanagers.monitoring.coreos.com
+	# @kubectl delete crd podmonitors.monitoring.coreos.com
+
 ## Create horizontal pod autoscalers for all relevant deployments
 # @kubectl autoscale deployment tracking-consumer --cpu-percent=80 --min=1 --max=$(GPU_MAX_TIMES_TWENTY)
 kubectl/implement/autoscaling:


### PR DESCRIPTION
`prometheus-operator` creates Custom Resource Definitions when being deployed via `helm`.  These CRDs must be manually deleted after running `helm delete prometheus-operator --purge`, or else `helmfile sync` will not be able to re-deploy.

The added command, `make kubectl/destroy/prometheus-operator`, conveniently packages all of the required destruction commands.

For further information, consult the [prometheus-operator chart README](https://github.com/helm/charts/tree/master/stable/prometheus-operator#uninstalling-the-chart).