### PR TITLE
Fix resize splash screen causing exit bug

### DIFF
--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -491,7 +491,9 @@ function main() {
                       "\n\nThis Kiosk was developed by the Van Valen Lab at"
                       "the California Institute of Technology."
                       "\n\nhttps://vanvalenlab.caltech.edu")
-  msgbox "Welcome!" "${welcome_text[*]}"
+
+  dialog --backtitle "$BRAND" --title "Welcome!" --clear --msgbox \
+         "${welcome_text[*]}" 12 60
 
   while true; do
     ACTION=$(menu)


### PR DESCRIPTION
`msgbox` the function was handling the resize poorly.  By replacing it with raw dialog, the menu no longer crashes.

The resize still provides input to the splash screen and clicks the OK button, which is not desired behavior, but it no longer crashes so this can be a lower priority issue.

Fixes #231 