### PR TITLE
Add error code check and message for execution of gke login

### DIFF
--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -262,7 +262,7 @@ function configure_gke() {
     if ! make gke/login; then
       export CLOUD_PROVIDER=""
       local error_text=("\n\nAuthorization failed. Unable to continue setup procedure."
-                      "\n\nPlease verify your Google Cloud credentials and try again.")
+                        "\n\nPlease verify your Google Cloud credentials and try again.")
 
       dialog --backtitle "$BRAND" --title "GKE Login Failed" --clear --msgbox \
          "${error_text[*]}" 10 65

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -260,7 +260,7 @@ function configure_gke() {
   # authenticate with gcloud if necessary
   if [ "${current_account}" = "" ]; then
     if ! make gke/login; then
-
+      export CLOUD_PROVIDER=""
       local error_text=("\n\nAuthorization failed. Unable to continue setup procedure."
                       "\n\nPlease verify your Google Cloud credentials and try again.")
 

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -259,7 +259,16 @@ function configure_gke() {
   fi
   # authenticate with gcloud if necessary
   if [ "${current_account}" = "" ]; then
-    make gke/login
+    if ! make gke/login; then
+
+      local error_text=("\n\nAuthorization failed. Unable to continue setup procedure."
+                      "\n\nPlease verify your Google Cloud credentials and try again.")
+
+      dialog --backtitle "$BRAND" --title "GKE Login Failed" --clear --msgbox \
+         "${error_text[*]}" 10 65
+
+      return 0
+    fi
   fi
 
   # select a project with GPUs available


### PR DESCRIPTION
When make gke/login is run, it returns an error code if the cloud authorization failed. We make use of this error code and use it alert the user that they should verify GCloud credentials before proceeding with cluster configuration. We then exit cluster configuration and return to the main menu.

This partly addresses #215. 

It should be noted, however, that if a user has cached credentials, opts to use a new account and fails to authenticate, it is likely that if they select "Create cluster" from the main menu, a cluster will be created using cached credentials. This could be addressed as part of #184

Fixes #215 