### PR TITLE
Update autoscaler chart for new 0.4.0 release

### DIFF
--- a/conf/charts/autoscaler/Chart.yaml
+++ b/conf/charts/autoscaler/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: autoscaler
-version: 0.1.0
+version: 0.2.0
 #kubeVersion: ^1.10.0
 description: This project monitors the Redis database to scale the GPU nodes and tf-serving and flask containers as necessary.
 keywords:

--- a/conf/charts/autoscaler/Chart.yaml
+++ b/conf/charts/autoscaler/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: autoscaler
-version: 0.2.0
+version: 0.1.0
 #kubeVersion: ^1.10.0
 description: This project monitors the Redis database to scale the GPU nodes and tf-serving and flask containers as necessary.
 keywords:

--- a/conf/charts/autoscaler/values.yaml
+++ b/conf/charts/autoscaler/values.yaml
@@ -24,9 +24,16 @@ rbac:
   pspEnabled: false
 
 env:
+  RESOURCE_NAME: "tf-serving"
+  RESOURCE_TYPE: "deployment"
+  RESOURCE_NAMESPACE: "default"
   DEBUG: "true"
-  INTERVAL: 10
+  INTERVAL: 5
   REDIS_HOST: "redis-master"
   REDIS_PORT: "6379"
+  REDIS_INTERVAL: 1
   QUEUES: "segmentation,tracking"
-  AUTOSCALING: "3|10|5|deployment|example; 3|5|3|development|example2"
+  QUEUE_DELIMITER: ","
+  MAX_PODS: 1
+  MIN_PODS: 0
+  KEYS_PER_POD: 1

--- a/conf/helmfile.d/0210.autoscaler.yaml
+++ b/conf/helmfile.d/0210.autoscaler.yaml
@@ -30,7 +30,7 @@ releases:
 
       image:
         repository: "vanvalenlab/kiosk-autoscaler"
-        tag: "0.3.0"
+        tag: "0.4.0-rc"
         pullPolicy: "Always"
 
       serviceAccount:
@@ -48,14 +48,18 @@ releases:
         #   cpu: 100m
         #   memory: 64Mi
 
-# 1|{{ env "GPU_NODE_MAX_SIZE" | default 10 }}|1|deepcell|deployment|segmentation|zip-consumer;
       env:
+        QUEUES: "segmentation,tracking"
+        QUEUE_DELIMITER: ","
+        RESOURCE_NAME: "tf-serving"
+        RESOURCE_TYPE: "deployment"
+        RESOURCE_NAMESPACE: "deepcell"
         DEBUG: "true"
-        INTERVAL: "5"
-        QUEUES: "predict,track"
+        INTERVAL: 5
         REDIS_HOST: "redis"
-        REDIS_PORT: "26379"
-        AUTOSCALING: >
-            {{ env "GPU_NODE_MIN_SIZE" | default 0 }}|{{ env "GPU_NODE_MAX_SIZE" | default 5 }}|1|deepcell|deployment|segmentation|tf-serving;
-            {{ env "GPU_NODE_MIN_SIZE" | default 0 }}|{{ env "GPU_NODE_MAX_SIZE" | default 5 }}|1|deepcell|deployment|tracking|tf-serving;
-            0|4|1|deepcell|job|train|training
+        REDIS_PORT: 26379
+        REDIS_INTERVAL: 1
+        # These should not change
+        MAX_PODS: 1
+        MIN_PODS: 0
+        KEYS_PER_POD: 1

--- a/conf/helmfile.d/0210.autoscaler.yaml
+++ b/conf/helmfile.d/0210.autoscaler.yaml
@@ -61,5 +61,5 @@ releases:
         REDIS_INTERVAL: 1
         # These should not change
         MAX_PODS: 1
-        MIN_PODS: 0
+        MIN_PODS: '{{ env "GPU_NODE_MIN_SIZE" | default 0 }}'
         KEYS_PER_POD: 1

--- a/conf/helmfile.d/0210.autoscaler.yaml
+++ b/conf/helmfile.d/0210.autoscaler.yaml
@@ -30,7 +30,7 @@ releases:
 
       image:
         repository: "vanvalenlab/kiosk-autoscaler"
-        tag: "0.4.0-rc"
+        tag: "0.4.0"
         pullPolicy: "Always"
 
       serviceAccount:


### PR DESCRIPTION
The 0.4.0 release of the kiosk-autoscaler updates the required environment variables, and limits the autoscaler to only one GPU resource that is scaled.  This prevents the single autoscaler from scaling the training GPU (which is currently disabled).

Further releases of the autoscaler may re-introduce this functionality but for now, scaling another GPU pool will require another autoscaler for that pool.