### PR TITLE
decreasing Prometheus' scrape and evaluation intervals to 15 seconds

### DIFF
--- a/conf/helmfile.d/0600.prometheus-operator.yaml
+++ b/conf/helmfile.d/0600.prometheus-operator.yaml
@@ -1182,11 +1182,11 @@ releases:
 
           ## Interval between consecutive scrapes.
           ##
-          scrapeInterval: ""
+          scrapeInterval: 15s
 
           ## Interval between consecutive evaluations.
           ##
-          evaluationInterval: ""
+          evaluationInterval: 15s
 
           ## ListenLocal makes the Prometheus server listen on loopback, so that it does not bind against the Pod IP.
           ##


### PR DESCRIPTION
### Changes
In response to issue #187, I bumped the default `scrapeInterval` and `evaluationInterval` for Prometheus up from 30 seconds to 15 seconds, as described  in solution 2 of my comment on #187:

> This requires only two changes: in the prometheus-operator Helmfile, we'd change
> values: prometheus: prometheusSpec: scrapeInterval:
> and
> values: prometheus: prometheusSpec: evaluatoinInterval:
> from “” to 15s.

### Testing
To test these changes, I started ten different clusters. In each one, I looked at the `prometheus-adapter` pod's logs to see whether any of our custom Prometheus metrics were returning 404s. Separately, in each cluster, I used Grafana to test whether the formula for the `zip_consumer_key_ratio` custom Prometheus metric would return data when queried by hand. Across all ten clusters, not a single 404 was observed for our custom metrics and, further, the formula pasted into Grafana returned a complete data series with no missing values every time.

As I noted in my comment to #187, the potential drawbacks to decreasing Prometheus' scrape and evaluation intervals are increased CPU and storage usage. I didn't run any tests on storage usage, partly because it's cheap and, thus, probably already over-allocated, and partly because I'm just not sure how to test storage easily. For CPU usage, though, in 8 of the 10 clusters I created, I waited at least ten minutes after cluster creation and then checked CPU usage in the `prometheus-operator` pod via Grafana as follows:
`rate (container_cpu_usage_seconds_total{pod_name="prometheus-prometheus-operator-prometheus-0"}[1m])`
In every case, CPU usage was stable over time and at less than 10% of the allocation CPU budget for the pod.

### Further Work

Hopefully, in addition to resolving #187, this pull request will also increase the responsiveness of the cluster during scale-up and scale-down. I didn't test whether this pull request actually leads to HPA metrics every 15 seconds, but that might be worth either verifying before merging into `master` or creating a new issue tagged "enhancement" to ensure that behavior is in place.

---

Fixes #187 