### PR TITLE
Set all custom charts image.pullPolicy to IfNotPresent

### DIFF
--- a/conf/charts/autoscaler/values.yaml
+++ b/conf/charts/autoscaler/values.yaml
@@ -5,9 +5,9 @@
 replicas: 1
 
 image:
-  repository: "vanvalenlab/kiosk-autoscaler"
-  tag: "latest"
-  pullPolicy: "Always"
+  repository: vanvalenlab/kiosk-autoscaler
+  tag: latest
+  pullPolicy: IfNotPresent
 
 resources: {}
 

--- a/conf/charts/benchmarking/values.yaml
+++ b/conf/charts/benchmarking/values.yaml
@@ -5,9 +5,9 @@
 replicas: 1
 
 image:
-  repository: "vanvalenlab/kiosk-benchmarking"
-  tag: "latest"
-  pullPolicy: "Always"
+  repository: vanvalenlab/kiosk-benchmarking
+  tag: latest
+  pullPolicy: IfNotPresent
 
 resources: {}
 

--- a/conf/charts/bucket-monitor/values.yaml
+++ b/conf/charts/bucket-monitor/values.yaml
@@ -5,9 +5,9 @@
 replicas: 1
 
 image:
-  repository: "vanvalenlab/kiosk-bucket-monitor"
-  tag: "latest"
-  pullPolicy: "Always"
+  repository: vanvalenlab/kiosk-bucket-monitor
+  tag: latest
+  pullPolicy: IfNotPresent
 
 resources: {}
 

--- a/conf/charts/data-processing/values.yaml
+++ b/conf/charts/data-processing/values.yaml
@@ -5,9 +5,9 @@
 replicas: 1
 
 image:
-  repository: "vanvalenlab/kiosk-data-processing"
-  tag: "latest"
-  pullPolicy: "Always"
+  repository: vanvalenlab/kiosk-data-processing
+  tag: latest
+  pullPolicy: IfNotPresent
 
 resources: {}
 

--- a/conf/charts/frontend/values.yaml
+++ b/conf/charts/frontend/values.yaml
@@ -5,9 +5,9 @@
 replicas: 1
 
 image:
-  repository: "vanvalenlab/kiosk-frontend"
-  tag: "latest"
-  pullPolicy: "Always"
+  repository: vanvalenlab/kiosk-frontend
+  tag: latest
+  pullPolicy: IfNotPresent
 
 ingress:
   enabled: true

--- a/conf/charts/redis-consumer/values.yaml
+++ b/conf/charts/redis-consumer/values.yaml
@@ -5,9 +5,9 @@
 replicas: 1
 
 image:
-  repository: "vanvalenlab/kiosk-redis-consumer"
-  tag: "latest"
-  pullPolicy: "Always"
+  repository: vanvalenlab/kiosk-redis-consumer
+  tag: latest
+  pullPolicy: IfNotPresent
 
 resources: {}
 

--- a/conf/charts/redis-janitor/values.yaml
+++ b/conf/charts/redis-janitor/values.yaml
@@ -5,9 +5,9 @@
 replicas: 1
 
 image:
-  repository: "vanvalenlab/kiosk-redis-janitor"
-  tag: "latest"
-  pullPolicy: "Always"
+  repository: vanvalenlab/kiosk-redis-janitor
+  tag: latest
+  pullPolicy: IfNotPresent
 
 resources: {}
 

--- a/conf/charts/tensorboard/values.yaml
+++ b/conf/charts/tensorboard/values.yaml
@@ -5,9 +5,9 @@
 replicas: 1
 
 image:
-  repository: "vanvalenlab/kiosk-tensorboard"
-  tag: "latest"
-  pullPolicy: "Always"
+  repository: vanvalenlab/kiosk-tensorboard
+  tag: latest
+  pullPolicy: IfNotPresent
 
 resources: {}
 

--- a/conf/charts/tf-serving/values.yaml
+++ b/conf/charts/tf-serving/values.yaml
@@ -5,12 +5,12 @@
 replicas: 0
 
 image:
-  repository: "vanvalenlab/kiosk-tf-serving"
-  tag: "latest"
-  pullPolicy: "Always"
+  repository: vanvalenlab/kiosk-tf-serving
+  tag: latest
+  pullPolicy: IfNotPresent
 
 service:
-  type: "ClusterIP"
+  type: ClusterIP
 
   httpIngressEnabled: true
   internalHttpPort: 8501

--- a/conf/charts/training/values.yaml
+++ b/conf/charts/training/values.yaml
@@ -5,14 +5,14 @@
 parallelism: 0
 
 image:
-  repository: "vanvalenlab/kiosk-training"
-  tag: "latest"
-  pullPolicy: "Always"
+  repository: vanvalenlab/kiosk-training
+  tag: latest
+  pullPolicy: IfNotPresent
 
 resources: {}
 
 service:
-  type: "ClusterIP"
+  type: ClusterIP
 
   httpIngressEnabled: true
   internalHttpPort: 7241

--- a/conf/helmfile.d/0200.bucket-monitor.yaml
+++ b/conf/helmfile.d/0200.bucket-monitor.yaml
@@ -29,7 +29,6 @@ releases:
       image:
         repository: "vanvalenlab/kiosk-bucket-monitor"
         tag: "0.3.0"
-        pullPolicy: "Always"
 
       resources:
         requests:

--- a/conf/helmfile.d/0210.autoscaler.yaml
+++ b/conf/helmfile.d/0210.autoscaler.yaml
@@ -29,7 +29,6 @@ releases:
       image:
         repository: "vanvalenlab/kiosk-autoscaler"
         tag: "0.4.0"
-        pullPolicy: "Always"
 
       serviceAccount:
         # Specifies whether a ServiceAccount should be created

--- a/conf/helmfile.d/0220.redis-janitor.yaml
+++ b/conf/helmfile.d/0220.redis-janitor.yaml
@@ -29,7 +29,6 @@ releases:
       image:
         repository: "vanvalenlab/kiosk-redis-janitor"
         tag: "0.3.0"
-        pullPolicy: "Always"
 
       serviceAccount:
         # Specifies whether a ServiceAccount should be created

--- a/conf/helmfile.d/0230.segmentation-consumer.yaml
+++ b/conf/helmfile.d/0230.segmentation-consumer.yaml
@@ -29,7 +29,6 @@ releases:
       image:
         repository: "vanvalenlab/kiosk-redis-consumer"
         tag: "0.4.4"
-        pullPolicy: "Always"
 
       nameOverride: "segmentation-consumer"
 

--- a/conf/helmfile.d/0240.zip-consumer.yaml
+++ b/conf/helmfile.d/0240.zip-consumer.yaml
@@ -29,7 +29,6 @@ releases:
       image:
         repository: "vanvalenlab/kiosk-redis-consumer"
         tag: "0.4.4"
-        pullPolicy: "Always"
 
       nameOverride: zip-consumer
 

--- a/conf/helmfile.d/0250.tracking-consumer.yaml
+++ b/conf/helmfile.d/0250.tracking-consumer.yaml
@@ -29,7 +29,6 @@ releases:
       image:
         repository: "vanvalenlab/kiosk-redis-consumer"
         tag: "0.4.4"
-        pullPolicy: "Always"
 
       nameOverride: "tracking-consumer"
 

--- a/conf/helmfile.d/0300.frontend.yaml
+++ b/conf/helmfile.d/0300.frontend.yaml
@@ -29,7 +29,6 @@ releases:
       image:
         repository: vanvalenlab/kiosk-frontend
         tag: 0.4.0
-        pullPolicy: Always
 
       resources:
         requests:

--- a/conf/helmfile.d/0310.tf-serving.yaml
+++ b/conf/helmfile.d/0310.tf-serving.yaml
@@ -29,7 +29,6 @@ releases:
       image:
         repository: "vanvalenlab/kiosk-tf-serving"
         tag: "0.2.1"
-        pullPolicy: "Always"
 
       resources:
         requests:

--- a/conf/helmfile.d/0320.tensorboard.yaml
+++ b/conf/helmfile.d/0320.tensorboard.yaml
@@ -29,7 +29,6 @@ releases:
       image:
         repository: "vanvalenlab/kiosk-tensorboard"
         tag: "0.1"
-        pullPolicy: "Always"
 
       service:
         type: "ClusterIP"

--- a/conf/helmfile.d/0399.data-processing.yaml
+++ b/conf/helmfile.d/0399.data-processing.yaml
@@ -29,7 +29,6 @@ releases:
       image:
         repository: "vanvalenlab/kiosk-data-processing"
         tag: "0.1"
-        pullPolicy: "Always"
 
       service:
         type: "ClusterIP"

--- a/conf/helmfile.d/0400.training-job.yaml
+++ b/conf/helmfile.d/0400.training-job.yaml
@@ -29,7 +29,6 @@ releases:
       image:
         repository: "vanvalenlab/kiosk-training"
         tag: "0.1"
-        pullPolicy: "Always"
 
       service:
         type: "ClusterIP"

--- a/conf/helmfile.d/0410.benchmarking.yaml
+++ b/conf/helmfile.d/0410.benchmarking.yaml
@@ -29,7 +29,6 @@ releases:
       image:
         repository: vanvalenlab/kiosk-benchmarking
         tag: 0.2.3
-        pullPolicy: Always
 
       resources:
         requests:


### PR DESCRIPTION
No need to pull images for all containers if it already exists. This should reduce the deployment time of new pods.