### PR TITLE
Limit cluster names to at most 18 characters.

### DIFF
--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -298,7 +298,7 @@ function configure_gke() {
     if [ "$CLOUDSDK_CONTAINER_CLUSTER" = "" ]; then
       return 0
     elif [ ${#CLOUDSDK_CONTAINER_CLUSTER} -gt 18 ]; then
-      msgbox "Warning!" "Please make sure your cluster name is less than 18 characters."
+      msgbox "Warning!" "Please make sure your cluster name is no more than 18 characters."
     fi
     export CLOUDSDK_CONTAINER_CLUSTER=$(inputbox "Deepcell" "Cluster Name" "${CLOUDSDK_CONTAINER_CLUSTER:-deepcell-cluster}")
     export CLOUDSDK_CONTAINER_CLUSTER=$(echo ${CLOUDSDK_CONTAINER_CLUSTER} | awk '{print tolower($0)}' | sed -E 's/[^a-z0-9]+/-/g' | sed -E 's/(^-+|-+$)//')

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -289,11 +289,20 @@ function configure_gke() {
   if [ -z ${CLOUDSDK_CONTAINER_CLUSTER} ]; then
     export CLOUDSDK_CONTAINER_CLUSTER="deepcell-$(shuf -n 1 /etc/wordlist.txt)-$((1 + RANDOM % 100))"
   fi
+
   export CLOUDSDK_CONTAINER_CLUSTER=$(inputbox "Deepcell" "Cluster Name" "${CLOUDSDK_CONTAINER_CLUSTER:-deepcell-cluster}")
   export CLOUDSDK_CONTAINER_CLUSTER=$(echo ${CLOUDSDK_CONTAINER_CLUSTER} | awk '{print tolower($0)}' | sed -E 's/[^a-z0-9]+/-/g' | sed -E 's/(^-+|-+$)//')
-  if [ "$CLOUDSDK_CONTAINER_CLUSTER" = "" ]; then
-    return 0
-  fi
+  # If clusters are longer than 18 characters, Persistent Disks can get stranded.
+  while [ "${CLOUDSDK_CONTAINER_CLUSTER}" = "" -o ${#CLOUDSDK_CONTAINER_CLUSTER} -gt 18 ]
+  do
+    if [ "$CLOUDSDK_CONTAINER_CLUSTER" = "" ]; then
+      return 0
+    elif [ ${#CLOUDSDK_CONTAINER_CLUSTER} -gt 18 ]; then
+      msgbox "Warning!" "Please make sure your cluster name is less than 18 characters."
+    fi
+    export CLOUDSDK_CONTAINER_CLUSTER=$(inputbox "Deepcell" "Cluster Name" "${CLOUDSDK_CONTAINER_CLUSTER:-deepcell-cluster}")
+    export CLOUDSDK_CONTAINER_CLUSTER=$(echo ${CLOUDSDK_CONTAINER_CLUSTER} | awk '{print tolower($0)}' | sed -E 's/[^a-z0-9]+/-/g' | sed -E 's/(^-+|-+$)//')
+  done
 
   # Get the bucket name from the user or the environment
   local bucket_text=("Bucket Name"

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -287,7 +287,7 @@ function configure_gke() {
 
   # Get the cluster name from the user or the environment
   if [ -z ${CLOUDSDK_CONTAINER_CLUSTER} ]; then
-    export CLOUDSDK_CONTAINER_CLUSTER="deepcell-$(shuf -n 1 /etc/wordlist.txt)-$((1 + RANDOM % 100))"
+    export CLOUDSDK_CONTAINER_CLUSTER="deepcell-$((1 + RANDOM % 100))"
   fi
 
   export CLOUDSDK_CONTAINER_CLUSTER=$(inputbox "Deepcell" "Cluster Name" "${CLOUDSDK_CONTAINER_CLUSTER:-deepcell-cluster}")


### PR DESCRIPTION
Persistent Disks were not able to be deleted because the cluster name was truncated from the PD name.  This means that our `grep` for the cluster name came up with no results if the cluster name is too long.

This PR Fixes #256 by limiting cluster names to at most 18 characters, and removing the random wordlist from the default names.  Now our default suggestions have a valid length and we will not allow users to create a word list that is too long.