### PR TITLE
Suppress gcloud auth login errors

### DIFF
--- a/scripts/gcloud-login.sh
+++ b/scripts/gcloud-login.sh
@@ -19,9 +19,8 @@ else
   # If so, just ignore the error.
   # NB: Ideally, we'd grab this info directly from the gcloud auth login command,
   # but the command is written in such a way that that's very difficult.
-  project_failure=$( \
-	  cat $(gcloud info --format "value(logs.last_log)") | \
-	  grep "ERROR    root            (gcloud.auth.login) The project property is set to the empty string, which is invalid.")
+  auth_logfile=$(gcloud info --format "value(logs.last_log)")
+  project_failure=$(grep -E 'ERROR.*The project property is set to the empty string, which is invalid.' $auth_logfile)
   if [[ -z "${project_failure}" ]]; then
     echo "Login failed!"
     exit 1

--- a/scripts/gcloud-login.sh
+++ b/scripts/gcloud-login.sh
@@ -2,14 +2,30 @@
 
 clear
 
+# Print text to explain this confusing screen to the user.
 echo "Deploying a cluster on Google Cloud requires authorization."
 echo ""
 
-gcloud auth login --no-launch-browser --verbosity "error"
+# Print crazy link to screen and prompt user to paste confirmation code received from browser.
+# NB: --verbosity "critical": That is to suppress ERRORs when the authenticated account
+#     doesn't have a default project. (See below.) This is for purposes of UI aesthetics.
+gcloud auth login --no-launch-browser --verbosity "critical"
 
+# Now, evaluate whether the script succeeded or failed.
 if [ $? -eq 0 ]; then
   echo "Success!"
 else
-  echo "Login failed!"
-  exit 1
+  # Check to see whether the command authenticated, but failed due to an unset default project.
+  # If so, just ignore the error.
+  # NB: Ideally, we'd grab this info directly from the gcloud auth login command,
+  # but the command is written in such a way that that's very difficult.
+  project_failure=$( \
+	  cat $(gcloud info --format "value(logs.last_log)") | \
+	  grep "ERROR    root            (gcloud.auth.login) The project property is set to the empty string, which is invalid.")
+  if [[ -z "${project_failure}" ]]; then
+    echo "Login failed!"
+    exit 1
+  else
+    echo "Success!"
+  fi
 fi

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -268,7 +268,6 @@ function configure_gke() {
                         "\n")
       dialog --backtitle "$BRAND" --title "GKE Login Failed" --clear --msgbox \
          "${error_text[*]}" 9 65
-
       return 0
     fi
   fi


### PR DESCRIPTION
Fixes #249.

For the record:
```
gcloud --version
Google Cloud SDK 265.0.0
bq 2.0.48
core 2019.09.27
gsutil 4.43
```


After trying a lot of other stuff that relied on Google's recommended `gcloud ... --format --filter` output formatting, it was apparent that there's just no substitute to being able to parse the actual error message that `gcloud auth login` returns. However, it's worth noting that this improvement may break whenever `gcloud` is upgraded. That said, it's much simpler than any `--format`-weilding solution; it's almost impossible to write one of those that's fool-proof.