### PR TITLE
adding warning about large text dumps to shell

### DIFF
--- a/docs/ADVANCED_DOCUMENTATION.md
+++ b/docs/ADVANCED_DOCUMENTATION.md
@@ -24,9 +24,12 @@ Welcome to the advanced documentation for DeepCell Kiosk developers. We will go 
 
 #### Shell Latency
 
-When testing new features or workflows, DeepCell Kiosk developers will often find themselves using the built-in terminal inside the Kiosk. (Accessible via the Kiosk's main menu as the "Shell" option.) This is a standard `bash` shell and should be familiar to most developers. Note that, if you are utilizing any of the advanced Kiosk deployment workflows, there can be a significant amount of latency in your terminal response time. Most of the time, this won't be a problem at all.
+When testing new features or workflows, DeepCell Kiosk developers will often find themselves using the built-in terminal inside the Kiosk. (Accessible via the Kiosk's main menu as the "Shell" option.) This is a standard `bash` shell and should be familiar to most developers. If you are using one of the [advanced Kiosk deployment workflows](#jumpbox) (which increases shell latency slightly), you should avoid printing unknown and potentially large amounts of text to the screen.
 
-However, in some extreme cases where a lot of text is being printed to the terminal (like if you query the logs of busy pods inside a long-running Kubernetes cluster), your terminal can be rendered effectively frozen for long periods of time (say, possibly an hour). In our opinion, this situation is best avoided. To this end, we recommend piping any command that might print a large amount of text to the terminal through a `tail` command (e.g., `kubectl logs [pod_name] | tail`) when using an advanced Kiosk deployment workflow.
+This usually only comes up in the context of logs. We know of two safe options for viewing logs:
+
+	1. `stern [pod_name_pattern] -s [duration]` (https://github.com/wercker/stern), which is useful when you want to view logs from now until `[duration]` minutes/seconds/etc. in the past for all pod's whose names match `[pod_name_duration]`
+	2. `kubectl logs [pod_name] --tail [N]`, which will print the last `[N]` lines of `[pod_name]`s logs
 
 <a name="adtoc1"></a>
 ### Building custom consumer pipelines

--- a/docs/ADVANCED_DOCUMENTATION.md
+++ b/docs/ADVANCED_DOCUMENTATION.md
@@ -2,6 +2,7 @@
 
 Welcome to the advanced documentation for DeepCell Kiosk developers. We will go over cluster customization, accessing cluster logs and metrics, less-common deployment workflows, a few design decisions that may be of interest to other developers, and other topics.
 
+* [Preliminaries](#adtoc0)
 * [Building custom consumer pipelines](#adtoc1)
    * [Deploying custom consumers](#adtoc1)
    * [Autoscaling custom consumers](#adtoc1b)
@@ -17,6 +18,12 @@ Welcome to the advanced documentation for DeepCell Kiosk developers. We will go 
    * [Google Cloud (Google Kubernetes Engine)](#failcd)
 * [Design decisions](#adtoc5)
    * [Database conventions](#adtoc5)
+
+<a name="adtoc0"></a>
+### Preliminaries
+
+	When testing new features or workflows, DeepCell Kiosk developers will often find themselves using the built-in terminal inside the Kiosk. (Accessible via the Kiosk's main menu as the "Shell" option.) This is a standard `bash` shell and should be familiar to most developers. Note that, if you are utilizing any of the advanced Kiosk deployment workflows, there can be a significant amount of latency in your terminal response time. Most of the time, this won't be a problem at all.
+	However, in some extreme cases where a lot of text is being printed to the terminal (like if you query the logs of busy pods inside a long-running Kubernetes cluster), your terminal can be rendered effectively frozen for long periods of time (say, possibly an hour). In our opinion, this situation is best avoided. To this end, we recommend piping any command that might print a large amount of text to the terminal through a `tail` command (e.g., `kubectl logs [pod_name] | tail`) when using an advanced Kiosk deployment workflow.
 
 <a name="adtoc1"></a>
 ### Building custom consumer pipelines

--- a/docs/ADVANCED_DOCUMENTATION.md
+++ b/docs/ADVANCED_DOCUMENTATION.md
@@ -22,8 +22,11 @@ Welcome to the advanced documentation for DeepCell Kiosk developers. We will go 
 <a name="adtoc0"></a>
 ### Preliminaries
 
-	When testing new features or workflows, DeepCell Kiosk developers will often find themselves using the built-in terminal inside the Kiosk. (Accessible via the Kiosk's main menu as the "Shell" option.) This is a standard `bash` shell and should be familiar to most developers. Note that, if you are utilizing any of the advanced Kiosk deployment workflows, there can be a significant amount of latency in your terminal response time. Most of the time, this won't be a problem at all.
-	However, in some extreme cases where a lot of text is being printed to the terminal (like if you query the logs of busy pods inside a long-running Kubernetes cluster), your terminal can be rendered effectively frozen for long periods of time (say, possibly an hour). In our opinion, this situation is best avoided. To this end, we recommend piping any command that might print a large amount of text to the terminal through a `tail` command (e.g., `kubectl logs [pod_name] | tail`) when using an advanced Kiosk deployment workflow.
+#### Shell Latency
+
+When testing new features or workflows, DeepCell Kiosk developers will often find themselves using the built-in terminal inside the Kiosk. (Accessible via the Kiosk's main menu as the "Shell" option.) This is a standard `bash` shell and should be familiar to most developers. Note that, if you are utilizing any of the advanced Kiosk deployment workflows, there can be a significant amount of latency in your terminal response time. Most of the time, this won't be a problem at all.
+
+However, in some extreme cases where a lot of text is being printed to the terminal (like if you query the logs of busy pods inside a long-running Kubernetes cluster), your terminal can be rendered effectively frozen for long periods of time (say, possibly an hour). In our opinion, this situation is best avoided. To this end, we recommend piping any command that might print a large amount of text to the terminal through a `tail` command (e.g., `kubectl logs [pod_name] | tail`) when using an advanced Kiosk deployment workflow.
 
 <a name="adtoc1"></a>
 ### Building custom consumer pipelines

--- a/docs/ADVANCED_DOCUMENTATION.md
+++ b/docs/ADVANCED_DOCUMENTATION.md
@@ -26,10 +26,11 @@ Welcome to the advanced documentation for DeepCell Kiosk developers. We will go 
 
 When testing new features or workflows, DeepCell Kiosk developers will often find themselves using the built-in terminal inside the Kiosk. (Accessible via the Kiosk's main menu as the "Shell" option.) This is a standard `bash` shell and should be familiar to most developers. If you are using one of the [advanced Kiosk deployment workflows](#jumpbox) (which increases shell latency slightly), you should avoid printing unknown and potentially large amounts of text to the screen.
 
-This usually only comes up in the context of logs. We know of two safe options for viewing logs:
+This usually only comes up in the context of logs. To prevent this issue, we recommend the following:
 
-	1. `stern [pod_name_pattern] -s [duration]` (https://github.com/wercker/stern), which is useful when you want to view logs from now until `[duration]` minutes/seconds/etc. in the past for all pod's whose names match `[pod_name_duration]`
-	2. `kubectl logs [pod_name] --tail [N]`, which will print the last `[N]` lines of `[pod_name]`s logs
+  1. [`stern`](https://github.com/wercker/stern) is useful for tailing logs of multiple pods using can use human-readable time lengths. For example, `stern consumer -s 10m` will tail the last 10 minutes of logs for all pods with "consumer" in their name.
+
+  2. When using `kubectl logs` be sure to include the `--tail N` option to limit the total number of lines being returned. For example, `kubectl logs [POD_NAME] --tail 100` to return the last 100 lines of the pod's logs.
 
 <a name="adtoc1"></a>
 ### Building custom consumer pipelines


### PR DESCRIPTION
Fixes #252.

Per the comments on #252, we're just going to live with the danger of the terminal freezing up upon large text dumps. To mitigate this risk as much as possible for other contributors to the project, I'm putting a big warning at the top of [Advanced Documentation](docs/ADVANCED_DOCUMENTATION.md).