### PR TITLE
Set max-height for radiobox_array

### DIFF
--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -73,6 +73,13 @@ function radiobox_from_array() {
   local selector_box_lines=$(($selector_box_lines+1))
   local total_lines=$(($base_box_height + $selector_box_lines))
 
+  # make sure the box stays within the screen
+  local screen_height=$(tput lines)
+  if [ $screen_height -lt $(($total_lines+6)) ]; then
+    local selector_box_lines=$(($screen_height-15))
+    local total_lines=$(($base_box_height + $selector_box_lines))
+  fi
+
   local formatted_arr=$(echo "${arr}" | awk '{print NR " " $1 " OFF"}')
   local arr_with_default=${formatted_arr/$default_value OFF/$default_value ON}
 

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -75,8 +75,9 @@ function radiobox_from_array() {
 
   # make sure the box stays within the screen
   local screen_height=$(tput lines)
-  if [ $screen_height -lt $(($total_lines+6)) ]; then
-    local selector_box_lines=$(($screen_height-15))
+  local padding=6
+  if [ $screen_height -lt $(($total_lines+$padding)) ]; then
+    local selector_box_lines=$(($screen_height-($base_box_height+$padding)))
     local total_lines=$(($base_box_height + $selector_box_lines))
   fi
 


### PR DESCRIPTION
This way we can prevent the `radiobox_array` from being too large and hitting the top of the screen. Purely an aesthetic change.