### PR TITLE
setting TRANSLATE_COLON_NOTATION=false by default

### DIFF
--- a/conf/Makefile
+++ b/conf/Makefile
@@ -1,4 +1,5 @@
 export CLOUD_PROVIDER ?= gke
+export TRANSLATE_COLON_NOTATION=false
 
 # The if statement is meant to keep this line from executing during testing.
 ifeq ($(CONF_PATH_PREFIX), )


### PR DESCRIPTION
Fixing `build-harness`-related bug, brought out by #268 somehow.

Fixes #288.