### PR TITLE
Update Redis consumer and model versions for TF 2.8

### DIFF
--- a/conf/charts/redis-consumer/Chart.yaml
+++ b/conf/charts/redis-consumer/Chart.yaml
@@ -13,6 +13,6 @@ maintainers:
     email: bbannon@caltech.edu
     url: vanvalen.caltech.edu
 engine: gotpl
-appVersion: 0.16.2
+appVersion: 0.17.1
 deprecated: false
 tillerVersion: ^2.9.1

--- a/conf/charts/redis-consumer/values.yaml
+++ b/conf/charts/redis-consumer/values.yaml
@@ -6,7 +6,7 @@ replicas: 1
 
 image:
   repository: vanvalenlab/kiosk-redis-consumer
-  tag: 0.16.2
+  tag: 0.17.1
   pullPolicy: IfNotPresent
 
 resources: {}

--- a/conf/helmfile.d/0230.segmentation-consumer.yaml
+++ b/conf/helmfile.d/0230.segmentation-consumer.yaml
@@ -87,7 +87,7 @@ releases:
 
         NUCLEAR_MODEL: "NuclearSegmentation:6"  # model-registry PR 17
 
-        PHASE_MODEL: "CytoplasmSegmentation:5"  # data-registry #164
+        PHASE_MODEL: "CytoplasmSegmentation:5"  # model-registry PR 17
 
         CYTOPLASM_MODEL: "CytoplasmSegmentation:5"  # data-registry #164
 

--- a/conf/helmfile.d/0230.segmentation-consumer.yaml
+++ b/conf/helmfile.d/0230.segmentation-consumer.yaml
@@ -85,7 +85,7 @@ releases:
         AWS_REGION: '{{ env "AWS_REGION" | default "us-east-1" }}'
         GKE_COMPUTE_ZONE: '{{ env "GKE_COMPUTE_ZONE" | default "us-west1-b" }}'
 
-        NUCLEAR_MODEL: "NuclearSegmentation:6"  # data-registry #188
+        NUCLEAR_MODEL: "NuclearSegmentation:6"  # model-registry PR 17
 
         PHASE_MODEL: "CytoplasmSegmentation:5"  # data-registry #164
 

--- a/conf/helmfile.d/0230.segmentation-consumer.yaml
+++ b/conf/helmfile.d/0230.segmentation-consumer.yaml
@@ -85,11 +85,11 @@ releases:
         AWS_REGION: '{{ env "AWS_REGION" | default "us-east-1" }}'
         GKE_COMPUTE_ZONE: '{{ env "GKE_COMPUTE_ZONE" | default "us-west1-b" }}'
 
-        NUCLEAR_MODEL: "NuclearSegmentation:5"  # data-registry #188
+        NUCLEAR_MODEL: "NuclearSegmentation:6"  # data-registry #188
 
-        PHASE_MODEL: "CytoplasmSegmentation:4"  # data-registry #164
+        PHASE_MODEL: "CytoplasmSegmentation:5"  # data-registry #164
 
-        CYTOPLASM_MODEL: "CytoplasmSegmentation:4"  # data-registry #164
+        CYTOPLASM_MODEL: "CytoplasmSegmentation:5"  # data-registry #164
 
         LABEL_DETECT_ENABLED: "false"
         LABEL_DETECT_MODEL: "LabelDetection:1"

--- a/conf/helmfile.d/0230.segmentation-consumer.yaml
+++ b/conf/helmfile.d/0230.segmentation-consumer.yaml
@@ -27,7 +27,7 @@ releases:
 
       image:
         repository: vanvalenlab/kiosk-redis-consumer
-        tag: 0.16.2
+        tag: 0.17.1
 
       nameOverride: segmentation-consumer
 

--- a/conf/helmfile.d/0230.segmentation-consumer.yaml
+++ b/conf/helmfile.d/0230.segmentation-consumer.yaml
@@ -89,7 +89,7 @@ releases:
 
         PHASE_MODEL: "CytoplasmSegmentation:5"  # model-registry PR 17
 
-        CYTOPLASM_MODEL: "CytoplasmSegmentation:5"  # data-registry #164
+        CYTOPLASM_MODEL: "CytoplasmSegmentation:5"  # model-registry PR 17
 
         LABEL_DETECT_ENABLED: "false"
         LABEL_DETECT_MODEL: "LabelDetection:1"

--- a/conf/helmfile.d/0231.segmentation-zip-consumer.yaml
+++ b/conf/helmfile.d/0231.segmentation-zip-consumer.yaml
@@ -27,7 +27,7 @@ releases:
 
       image:
         repository: vanvalenlab/kiosk-redis-consumer
-        tag: 0.16.2
+        tag: 0.17.1
 
       nameOverride: segmentation-zip-consumer
 

--- a/conf/helmfile.d/0250.caliban-consumer.yaml
+++ b/conf/helmfile.d/0250.caliban-consumer.yaml
@@ -92,8 +92,8 @@ releases:
         SCALE_DETECT_ENABLED: "false"
         SCALE_DETECT_MODEL: "ScaleDetection:1"
 
-        TRACKING_MODEL: "NuclearTrackingInf:6"  # from model-registry#24
-        NEIGHBORHOOD_ENCODER: "NuclearTrackingNE:6"  # from model-registry#24
+        TRACKING_MODEL: "NuclearTrackingInf:6"  # from model-registry PR 17
+        NEIGHBORHOOD_ENCODER: "NuclearTrackingNE:6"  # from model-registry PR 17
         DRIFT_CORRECT_ENABLED: "false"
         TRACK_LENGTH: 8
         BIRTH: 0.99

--- a/conf/helmfile.d/0250.caliban-consumer.yaml
+++ b/conf/helmfile.d/0250.caliban-consumer.yaml
@@ -27,7 +27,7 @@ releases:
 
       image:
         repository: vanvalenlab/kiosk-redis-consumer
-        tag: 0.16.2
+        tag: 0.17.1
 
       nameOverride: caliban-consumer
 

--- a/conf/helmfile.d/0250.caliban-consumer.yaml
+++ b/conf/helmfile.d/0250.caliban-consumer.yaml
@@ -92,8 +92,8 @@ releases:
         SCALE_DETECT_ENABLED: "false"
         SCALE_DETECT_MODEL: "ScaleDetection:1"
 
-        TRACKING_MODEL: "TrackingModelInf:5"  # from model-registry#24
-        NEIGHBORHOOD_ENCODER: "TrackingModelNE:3"  # from model-registry#24
+        TRACKING_MODEL: "TrackingModelInf:6"  # from model-registry#24
+        NEIGHBORHOOD_ENCODER: "TrackingModelNE:6"  # from model-registry#24
         DRIFT_CORRECT_ENABLED: "false"
         TRACK_LENGTH: 8
         BIRTH: 0.99

--- a/conf/helmfile.d/0250.caliban-consumer.yaml
+++ b/conf/helmfile.d/0250.caliban-consumer.yaml
@@ -80,7 +80,7 @@ releases:
 
         TF_HOST: "tf-serving"
         TF_PORT: 8500
-        TF_MAX_BATCH_SIZE: 64
+        TF_MAX_BATCH_SIZE: 32
         TF_MIN_MODEL_SIZE: 128
 
         AWS_REGION: '{{ env "AWS_REGION" | default "us-east-1" }}'
@@ -92,8 +92,8 @@ releases:
         SCALE_DETECT_ENABLED: "false"
         SCALE_DETECT_MODEL: "ScaleDetection:1"
 
-        TRACKING_MODEL: "TrackingModelInf:6"  # from model-registry#24
-        NEIGHBORHOOD_ENCODER: "TrackingModelNE:6"  # from model-registry#24
+        TRACKING_MODEL: "NuclearTrackingInf:6"  # from model-registry#24
+        NEIGHBORHOOD_ENCODER: "NuclearTrackingNE:6"  # from model-registry#24
         DRIFT_CORRECT_ENABLED: "false"
         TRACK_LENGTH: 8
         BIRTH: 0.99

--- a/conf/helmfile.d/0251.caliban-zip-consumer.yaml
+++ b/conf/helmfile.d/0251.caliban-zip-consumer.yaml
@@ -27,7 +27,7 @@ releases:
 
       image:
         repository: vanvalenlab/kiosk-redis-consumer
-        tag: 0.16.2
+        tag: 0.17.1
 
       nameOverride: caliban-zip-consumer
 

--- a/conf/helmfile.d/0260.mesmer-consumer.yaml
+++ b/conf/helmfile.d/0260.mesmer-consumer.yaml
@@ -74,7 +74,7 @@ releases:
 
         TF_HOST: "tf-serving"
         TF_PORT: 8500
-        TF_MAX_BATCH_SIZE: 32
+        TF_MAX_BATCH_SIZE: 8
         TF_MIN_MODEL_SIZE: 128
 
         AWS_REGION: '{{ env "AWS_REGION" | default "us-east-1" }}'

--- a/conf/helmfile.d/0260.mesmer-consumer.yaml
+++ b/conf/helmfile.d/0260.mesmer-consumer.yaml
@@ -23,7 +23,7 @@ releases:
 
       image:
         repository: vanvalenlab/kiosk-redis-consumer
-        tag: 0.16.2
+        tag: 0.17.1
 
       nameOverride: mesmer-consumer
 

--- a/conf/helmfile.d/0260.mesmer-consumer.yaml
+++ b/conf/helmfile.d/0260.mesmer-consumer.yaml
@@ -80,7 +80,7 @@ releases:
         AWS_REGION: '{{ env "AWS_REGION" | default "us-east-1" }}'
         GKE_COMPUTE_ZONE: '{{ env "GKE_COMPUTE_ZONE" | default "us-west1-b" }}'
 
-        MESMER_MODEL: MultiplexSegmentation:9  # From model-registry#15
+        MESMER_MODEL: MultiplexSegmentation:9  # From model-registry PR 17
         MESMER_COMPARTMENT: both
 
         LABEL_DETECT_ENABLED: "false"

--- a/conf/helmfile.d/0260.mesmer-consumer.yaml
+++ b/conf/helmfile.d/0260.mesmer-consumer.yaml
@@ -80,7 +80,7 @@ releases:
         AWS_REGION: '{{ env "AWS_REGION" | default "us-east-1" }}'
         GKE_COMPUTE_ZONE: '{{ env "GKE_COMPUTE_ZONE" | default "us-west1-b" }}'
 
-        MESMER_MODEL: MultiplexSegmentation:8  # From model-registry#15
+        MESMER_MODEL: MultiplexSegmentation:9  # From model-registry#15
         MESMER_COMPARTMENT: both
 
         LABEL_DETECT_ENABLED: "false"

--- a/conf/helmfile.d/0261.mesmer-zip-consumer.yaml
+++ b/conf/helmfile.d/0261.mesmer-zip-consumer.yaml
@@ -23,7 +23,7 @@ releases:
 
       image:
         repository: vanvalenlab/kiosk-redis-consumer
-        tag: 0.16.2
+        tag: 0.17.1
 
       nameOverride: mesmer-zip-consumer
 

--- a/conf/helmfile.d/0270.polaris-consumer.yaml
+++ b/conf/helmfile.d/0270.polaris-consumer.yaml
@@ -23,7 +23,7 @@ releases:
 
       image:
         repository: vanvalenlab/kiosk-redis-consumer
-        tag: 0.16.2
+        tag: 0.17.1
 
       nameOverride: polaris-consumer
 

--- a/conf/helmfile.d/0271.polaris-zip-consumer.yaml
+++ b/conf/helmfile.d/0271.polaris-zip-consumer.yaml
@@ -23,7 +23,7 @@ releases:
 
       image:
         repository: vanvalenlab/kiosk-redis-consumer
-        tag: 0.16.2
+        tag: 0.17.1
 
       nameOverride: polaris-zip-consumer
 

--- a/conf/helmfile.d/0280.spot-consumer.yaml
+++ b/conf/helmfile.d/0280.spot-consumer.yaml
@@ -80,7 +80,7 @@ releases:
         AWS_REGION: '{{ env "AWS_REGION" | default "us-east-1" }}'
         GKE_COMPUTE_ZONE: '{{ env "GKE_COMPUTE_ZONE" | default "us-west1-b" }}'
 
-        POLARIS_MODEL: SpotDetection:3
+        POLARIS_MODEL: SpotDetection:7
 
         LABEL_DETECT_ENABLED: "false"
         SCALE_DETECT_ENABLED: "false"

--- a/conf/helmfile.d/0280.spot-consumer.yaml
+++ b/conf/helmfile.d/0280.spot-consumer.yaml
@@ -23,7 +23,7 @@ releases:
 
       image:
         repository: vanvalenlab/kiosk-redis-consumer
-        tag: 0.16.2
+        tag: 0.17.1
 
       nameOverride: spot-consumer
 

--- a/conf/helmfile.d/0281.spot-zip-consumer.yaml
+++ b/conf/helmfile.d/0281.spot-zip-consumer.yaml
@@ -23,7 +23,7 @@ releases:
 
       image:
         repository: vanvalenlab/kiosk-redis-consumer
-        tag: 0.16.2
+        tag: 0.17.1
 
       nameOverride: spot-zip-consumer
 

--- a/conf/helmfile.d/0300.frontend.yaml
+++ b/conf/helmfile.d/0300.frontend.yaml
@@ -27,7 +27,7 @@ releases:
 
       image:
         repository: vanvalenlab/kiosk-frontend
-        tag: 0.11.2
+        tag: 0.11.3
 
       resources:
         requests:

--- a/conf/helmfile.d/0310.tf-serving.yaml
+++ b/conf/helmfile.d/0310.tf-serving.yaml
@@ -27,7 +27,7 @@ releases:
 
       image:
         repository: vanvalenlab/kiosk-tf-serving
-        tag: 0.5.0
+        tag: 0.6.0
 
       configWriter:
         mountedVolume:


### PR DESCRIPTION
This PR updates the version of the Redis consumers and model versions used in the Kiosk. The versions of the frontend and tf-serving images were also updated to reflect the most recent releases.