### PR TITLE
Update with tracking models associated with publication

### DIFF
--- a/conf/helmfile.d/0230.segmentation-consumer.yaml
+++ b/conf/helmfile.d/0230.segmentation-consumer.yaml
@@ -27,7 +27,7 @@ releases:
 
       image:
         repository: vanvalenlab/kiosk-redis-consumer
-        tag: 0.17.1
+        tag: 0.17.2
 
       nameOverride: segmentation-consumer
 

--- a/conf/helmfile.d/0230.segmentation-consumer.yaml
+++ b/conf/helmfile.d/0230.segmentation-consumer.yaml
@@ -85,7 +85,7 @@ releases:
         AWS_REGION: '{{ env "AWS_REGION" | default "us-east-1" }}'
         GKE_COMPUTE_ZONE: '{{ env "GKE_COMPUTE_ZONE" | default "us-west1-b" }}'
 
-        NUCLEAR_MODEL: "NuclearSegmentation:6"  # model-registry PR 17
+        NUCLEAR_MODEL: "NuclearSegmentation:75"  # tracking paper version
 
         PHASE_MODEL: "CytoplasmSegmentation:5"  # model-registry PR 17
 

--- a/conf/helmfile.d/0231.segmentation-zip-consumer.yaml
+++ b/conf/helmfile.d/0231.segmentation-zip-consumer.yaml
@@ -27,7 +27,7 @@ releases:
 
       image:
         repository: vanvalenlab/kiosk-redis-consumer
-        tag: 0.17.1
+        tag: 0.17.2
 
       nameOverride: segmentation-zip-consumer
 

--- a/conf/helmfile.d/0250.caliban-consumer.yaml
+++ b/conf/helmfile.d/0250.caliban-consumer.yaml
@@ -100,7 +100,7 @@ releases:
         DEATH: 0.99
         DIVISION: 0.01
         MAX_DISTANCE: 60
-        APPERANCE_DIM: 32
+        APPEARANCE_DIM: 32
         CROP_MODE: "resize"
         CALIBAN_NORM: True
 

--- a/conf/helmfile.d/0250.caliban-consumer.yaml
+++ b/conf/helmfile.d/0250.caliban-consumer.yaml
@@ -27,7 +27,7 @@ releases:
 
       image:
         repository: vanvalenlab/kiosk-redis-consumer
-        tag: 0.17.1
+        tag: 0.17.2
 
       nameOverride: caliban-consumer
 

--- a/conf/helmfile.d/0250.caliban-consumer.yaml
+++ b/conf/helmfile.d/0250.caliban-consumer.yaml
@@ -92,13 +92,17 @@ releases:
         SCALE_DETECT_ENABLED: "false"
         SCALE_DETECT_MODEL: "ScaleDetection:1"
 
-        TRACKING_MODEL: "NuclearTrackingInf:6"  # from model-registry PR 17
-        NEIGHBORHOOD_ENCODER: "NuclearTrackingNE:6"  # from model-registry PR 17
+        TRACKING_MODEL: "NuclearTrackingInf:75" # tracking paper version
+        NEIGHBORHOOD_ENCODER: "NuclearTrackingNE:75" # tracking paper version
         DRIFT_CORRECT_ENABLED: "false"
         TRACK_LENGTH: 8
         BIRTH: 0.99
         DEATH: 0.99
         DIVISION: 0.01
+        MAX_DISTANCE: 60
+        APPERANCE_DIM: 32
+        CROP_MODE: "resize"
+        CALIBAN_NORM: True
 
       secrets:
         AWS_ACCESS_KEY_ID: '{{ env "AWS_ACCESS_KEY_ID" | default "NA" }}'

--- a/conf/helmfile.d/0251.caliban-zip-consumer.yaml
+++ b/conf/helmfile.d/0251.caliban-zip-consumer.yaml
@@ -27,7 +27,7 @@ releases:
 
       image:
         repository: vanvalenlab/kiosk-redis-consumer
-        tag: 0.17.1
+        tag: 0.17.2
 
       nameOverride: caliban-zip-consumer
 

--- a/conf/helmfile.d/0260.mesmer-consumer.yaml
+++ b/conf/helmfile.d/0260.mesmer-consumer.yaml
@@ -23,7 +23,7 @@ releases:
 
       image:
         repository: vanvalenlab/kiosk-redis-consumer
-        tag: 0.17.1
+        tag: 0.17.2
 
       nameOverride: mesmer-consumer
 

--- a/conf/helmfile.d/0261.mesmer-zip-consumer.yaml
+++ b/conf/helmfile.d/0261.mesmer-zip-consumer.yaml
@@ -23,7 +23,7 @@ releases:
 
       image:
         repository: vanvalenlab/kiosk-redis-consumer
-        tag: 0.17.1
+        tag: 0.17.2
 
       nameOverride: mesmer-zip-consumer
 

--- a/conf/helmfile.d/0270.polaris-consumer.yaml
+++ b/conf/helmfile.d/0270.polaris-consumer.yaml
@@ -23,7 +23,7 @@ releases:
 
       image:
         repository: vanvalenlab/kiosk-redis-consumer
-        tag: 0.17.1
+        tag: 0.17.2
 
       nameOverride: polaris-consumer
 

--- a/conf/helmfile.d/0271.polaris-zip-consumer.yaml
+++ b/conf/helmfile.d/0271.polaris-zip-consumer.yaml
@@ -23,7 +23,7 @@ releases:
 
       image:
         repository: vanvalenlab/kiosk-redis-consumer
-        tag: 0.17.1
+        tag: 0.17.2
 
       nameOverride: polaris-zip-consumer
 

--- a/conf/helmfile.d/0280.spot-consumer.yaml
+++ b/conf/helmfile.d/0280.spot-consumer.yaml
@@ -23,7 +23,7 @@ releases:
 
       image:
         repository: vanvalenlab/kiosk-redis-consumer
-        tag: 0.17.1
+        tag: 0.17.2
 
       nameOverride: spot-consumer
 

--- a/conf/helmfile.d/0281.spot-zip-consumer.yaml
+++ b/conf/helmfile.d/0281.spot-zip-consumer.yaml
@@ -23,7 +23,7 @@ releases:
 
       image:
         repository: vanvalenlab/kiosk-redis-consumer
-        tag: 0.17.1
+        tag: 0.17.2
 
       nameOverride: spot-zip-consumer
 


### PR DESCRIPTION
- Bump to a new release of the redis consumer ~~(still pending)~~
- Add new tracking parameters to the caliban helmfile
- Update tracking model versions

~~This PR is currently blocked until we release 0.17.2 for the kiosk-redis-consumer.~~

Once merged this branch needs to be merged into prod and a new deployment of the kiosk set up.